### PR TITLE
Use pre-commit to fix linting in autogenerated content

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,6 +51,13 @@ jobs:
       - name: Update Tutorials metrics page
         run: ./cli/mktuts.py
 
+      - name: Use pre-commit to fix newly generated pages
+        run: |
+          conda install pre-commit
+          pre-commit install .
+          pre-commit run --all
+          pre-commit run --all
+
       - name: Commit new changes
         uses: EndBug/add-and-commit@v8
         with:

--- a/images/metrics/ecgtools-burndown.html
+++ b/images/metrics/ecgtools-burndown.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="c59c684b-2a9f-4236-877c-58790210e428" data-root-id="8305"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="8584">
           {"256b0fee-7b52-4577-8003-3d8f27132ee8":{"defs":[],"roots":{"references":[{"attributes":{"days":[1,15]},"id":"8350","type":"DaysTicker"},{"attributes":{"below":[{"id":"8316"}],"center":[{"id":"8319"},{"id":"8323"}],"height":200,"left":[{"id":"8320"}],"renderers":[{"id":"8333"}],"sizing_mode":"scale_width","title":{"id":"8306"},"toolbar":{"id":"8324"},"width":800,"x_range":{"id":"8308"},"x_scale":{"id":"8312"},"y_range":{"id":"8310"},"y_scale":{"id":"8314"}},"id":"8305","subtype":"Figure","type":"Plot"},{"attributes":{"tools":[{"id":"8304"}]},"id":"8324","type":"Toolbar"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Issues","@$name"],["Date","@month{%b %Y}"]]},"id":"8304","type":"HoverTool"},{"attributes":{},"id":"8314","type":"LinearScale"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"8344","type":"AdaptiveTicker"},{"attributes":{"months":[0,4,8]},"id":"8353","type":"MonthsTicker"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"8348","type":"DaysTicker"},{"attributes":{"source":{"id":"8328"}},"id":"8334","type":"CDSView"},{"attributes":{},"id":"8342","type":"UnionRenderers"},{"attributes":{},"id":"8355","type":"YearsTicker"},{"attributes":{"axis":{"id":"8316"},"coordinates":null,"group":null,"ticker":null},"id":"8319","type":"Grid"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"8345","type":"AdaptiveTicker"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"8352","type":"MonthsTicker"},{"attributes":{},"id":"8339","type":"AllLabels"},{"attributes":{"bottom":{"expr":{"id":"8326"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"8327"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"8330","type":"VBar"},{"attributes":{"data":{"month":[1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0],"nopen":[0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,2,4,4,4,4,4,4,4,4,4,4,4,4,5,8,8,9,12,13,13,14,13]},"selected":{"id":"8343"},"selection_policy":{"id":"8342"}},"id":"8328","type":"ColumnDataSource"},{"attributes":{"bottom":{"expr":{"id":"8326"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"8327"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"8332","type":"VBar"},{"attributes":{"coordinates":null,"group":null,"text":"Open Issues","text_font_size":"1rem"},"id":"8306","type":"Title"},{"attributes":{"coordinates":null,"data_source":{"id":"8328"},"glyph":{"id":"8330"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"8332"},"name":"nopen","nonselection_glyph":{"id":"8331"},"view":{"id":"8334"}},"id":"8333","type":"GlyphRenderer"},{"attributes":{"end":15.400000000000002},"id":"8310","type":"Range1d"},{"attributes":{},"id":"8321","type":"BasicTicker"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"8346","type":"AdaptiveTicker"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"8344"},{"id":"8345"},{"id":"8346"},{"id":"8347"},{"id":"8348"},{"id":"8349"},{"id":"8350"},{"id":"8351"},{"id":"8352"},{"id":"8353"},{"id":"8354"},{"id":"8355"}]},"id":"8317","type":"DatetimeTicker"},{"attributes":{"coordinates":null,"formatter":{"id":"8302"},"group":null,"major_label_policy":{"id":"8341"},"ticker":{"id":"8317"}},"id":"8316","type":"DatetimeAxis"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"8351","type":"MonthsTicker"},{"attributes":{},"id":"8341","type":"AllLabels"},{"attributes":{"end":1642464000000.0,"start":1544832000000.0},"id":"8308","type":"Range1d"},{"attributes":{"months":[0,6]},"id":"8354","type":"MonthsTicker"},{"attributes":{"format":"%6.1u"},"id":"8303","type":"PrintfTickFormatter"},{"attributes":{"fields":[]},"id":"8326","type":"Stack"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"8347","type":"DaysTicker"},{"attributes":{},"id":"8312","type":"LinearScale"},{"attributes":{"axis":{"id":"8320"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"8323","type":"Grid"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"8302","type":"DatetimeTickFormatter"},{"attributes":{},"id":"8343","type":"Selection"},{"attributes":{"days":[1,8,15,22]},"id":"8349","type":"DaysTicker"},{"attributes":{"fields":["nopen"]},"id":"8327","type":"Stack"},{"attributes":{"bottom":{"expr":{"id":"8326"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"8327"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"8331","type":"VBar"},{"attributes":{"coordinates":null,"formatter":{"id":"8303"},"group":null,"major_label_policy":{"id":"8339"},"ticker":{"id":"8321"}},"id":"8320","type":"LinearAxis"}],"root_ids":["8305"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('8584').textContent;
                   const render_items = [{"docid":"256b0fee-7b52-4577-8003-3d8f27132ee8","root_ids":["8305"],"roots":{"8305":"c59c684b-2a9f-4236-877c-58790210e428"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/ecgtools-commits.html
+++ b/images/metrics/ecgtools-commits.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="94c61ea6-de0e-4e09-b8b3-087330b74b99" data-root-id="4290"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="4651">
           {"8c5624b5-18c9-4379-a6ff-c16941732f4a":{"defs":[],"roots":{"references":[{"attributes":{"below":[{"id":"4301"}],"center":[{"id":"4304"},{"id":"4308"},{"id":"4343"}],"height":200,"left":[{"id":"4305"}],"renderers":[{"id":"4320"},{"id":"4350"}],"sizing_mode":"scale_width","title":{"id":"4291"},"toolbar":{"id":"4309"},"width":800,"x_range":{"id":"4293"},"x_scale":{"id":"4297"},"y_range":{"id":"4295"},"y_scale":{"id":"4299"}},"id":"4290","subtype":"Figure","type":"Plot"},{"attributes":{"source":{"id":"4315"}},"id":"4321","type":"CDSView"},{"attributes":{"coordinates":null,"formatter":{"id":"4287"},"group":null,"major_label_policy":{"id":"4328"},"ticker":{"id":"4302"}},"id":"4301","type":"DatetimeAxis"},{"attributes":{},"id":"4362","type":"Selection"},{"attributes":{"fields":[]},"id":"4311","type":"Stack"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"4339","type":"MonthsTicker"},{"attributes":{"months":[0,6]},"id":"4341","type":"MonthsTicker"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,571,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Internal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2579,21,0,0,0,0,0,0,0,0,2093,6024,4684,22,10,2285,0,0,196,432,1170],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"4330"},"selection_policy":{"id":"4329"}},"id":"4315","type":"ColumnDataSource"},{"attributes":{"axis":{"id":"4305"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"4308","type":"Grid"},{"attributes":{"bottom":{"expr":{"id":"4313"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"4314"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"4347","type":"VBar"},{"attributes":{"days":[1,8,15,22]},"id":"4336","type":"DaysTicker"},{"attributes":{"bottom":{"expr":{"id":"4313"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"4314"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"4349","type":"VBar"},{"attributes":{},"id":"4299","type":"LinearScale"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"4335","type":"DaysTicker"},{"attributes":{"axis":{"id":"4301"},"coordinates":null,"group":null,"ticker":null},"id":"4304","type":"Grid"},{"attributes":{"label":{"value":"Internal"},"renderers":[{"id":"4350"}]},"id":"4375","type":"LegendItem"},{"attributes":{"bottom":{"expr":{"id":"4311"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"4312"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"4318","type":"VBar"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"4334","type":"DaysTicker"},{"attributes":{"coordinates":null,"data_source":{"id":"4345"},"glyph":{"id":"4347"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"4349"},"name":"Internal","nonselection_glyph":{"id":"4348"},"view":{"id":"4351"}},"id":"4350","type":"GlyphRenderer"},{"attributes":{"tools":[{"id":"4289"}]},"id":"4309","type":"Toolbar"},{"attributes":{},"id":"4325","type":"AllLabels"},{"attributes":{"days":[1,15]},"id":"4337","type":"DaysTicker"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"4338","type":"MonthsTicker"},{"attributes":{"end":1645142400000.0,"start":1542153600000.0},"id":"4293","type":"Range1d"},{"attributes":{"bottom":{"expr":{"id":"4313"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"4314"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"4348","type":"VBar"},{"attributes":{},"id":"4330","type":"Selection"},{"attributes":{"format":"%6.1u"},"id":"4288","type":"PrintfTickFormatter"},{"attributes":{"months":[0,4,8]},"id":"4340","type":"MonthsTicker"},{"attributes":{},"id":"4342","type":"YearsTicker"},{"attributes":{"label":{"value":"External"},"renderers":[{"id":"4320"}]},"id":"4344","type":"LegendItem"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,571,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Internal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2579,21,0,0,0,0,0,0,0,0,2093,6024,4684,22,10,2285,0,0,196,432,1170],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"4362"},"selection_policy":{"id":"4361"}},"id":"4345","type":"ColumnDataSource"},{"attributes":{"source":{"id":"4345"}},"id":"4351","type":"CDSView"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"4331"},{"id":"4332"},{"id":"4333"},{"id":"4334"},{"id":"4335"},{"id":"4336"},{"id":"4337"},{"id":"4338"},{"id":"4339"},{"id":"4340"},{"id":"4341"},{"id":"4342"}]},"id":"4302","type":"DatetimeTicker"},{"attributes":{"fields":["External","Internal"]},"id":"4314","type":"Stack"},{"attributes":{"coordinates":null,"formatter":{"id":"4288"},"group":null,"major_label_policy":{"id":"4325"},"ticker":{"id":"4306"}},"id":"4305","type":"LinearAxis"},{"attributes":{},"id":"4329","type":"UnionRenderers"},{"attributes":{},"id":"4361","type":"UnionRenderers"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"4333","type":"AdaptiveTicker"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"4344"},{"id":"4375"}],"location":"top_left"},"id":"4343","type":"Legend"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"4287","type":"DatetimeTickFormatter"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"4332","type":"AdaptiveTicker"},{"attributes":{},"id":"4328","type":"AllLabels"},{"attributes":{"coordinates":null,"data_source":{"id":"4315"},"glyph":{"id":"4317"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"4319"},"name":"External","nonselection_glyph":{"id":"4318"},"view":{"id":"4321"}},"id":"4320","type":"GlyphRenderer"},{"attributes":{"fields":["External"]},"id":"4313","type":"Stack"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"4331","type":"AdaptiveTicker"},{"attributes":{"bottom":{"expr":{"id":"4311"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"4312"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"4317","type":"VBar"},{"attributes":{},"id":"4297","type":"LinearScale"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Commits","@$name"],["Date","@month{%b %Y}"]]},"id":"4289","type":"HoverTool"},{"attributes":{"fields":["External"]},"id":"4312","type":"Stack"},{"attributes":{},"id":"4306","type":"BasicTicker"},{"attributes":{"bottom":{"expr":{"id":"4311"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"4312"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"4319","type":"VBar"},{"attributes":{"coordinates":null,"group":null,"text":"Repository Commits","text_font_size":"1rem"},"id":"4291","type":"Title"},{"attributes":{"end":6626.400000000001},"id":"4295","type":"Range1d"}],"root_ids":["4290"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('4651').textContent;
                   const render_items = [{"docid":"8c5624b5-18c9-4379-a6ff-c16941732f4a","root_ids":["4290"],"roots":{"4290":"94c61ea6-de0e-4e09-b8b3-087330b74b99"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/ecgtools-contributors.html
+++ b/images/metrics/ecgtools-contributors.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="44d32dcc-fbf4-49ea-a1aa-f1f3a2152f33" data-root-id="5750"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="6111">
           {"37f81fcd-b218-478f-8234-b86a5722136a":{"defs":[],"roots":{"references":[{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"5794","type":"DaysTicker"},{"attributes":{"months":[0,6]},"id":"5801","type":"MonthsTicker"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],"Internal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2,2,2],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"5822"},"selection_policy":{"id":"5821"}},"id":"5805","type":"ColumnDataSource"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"5791","type":"AdaptiveTicker"},{"attributes":{"fields":["External"]},"id":"5773","type":"Stack"},{"attributes":{"bottom":{"expr":{"id":"5773"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"5774"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5807","type":"VBar"},{"attributes":{},"id":"5822","type":"Selection"},{"attributes":{"fields":["External"]},"id":"5772","type":"Stack"},{"attributes":{"bottom":{"expr":{"id":"5771"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"5772"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5779","type":"VBar"},{"attributes":{"days":[1,15]},"id":"5797","type":"DaysTicker"},{"attributes":{},"id":"5766","type":"BasicTicker"},{"attributes":{"bottom":{"expr":{"id":"5773"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"5774"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5808","type":"VBar"},{"attributes":{"days":[1,8,15,22]},"id":"5796","type":"DaysTicker"},{"attributes":{},"id":"5757","type":"LinearScale"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],"Internal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2,2,2],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"5790"},"selection_policy":{"id":"5789"}},"id":"5775","type":"ColumnDataSource"},{"attributes":{},"id":"5788","type":"AllLabels"},{"attributes":{"bottom":{"expr":{"id":"5771"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"5772"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5778","type":"VBar"},{"attributes":{"axis":{"id":"5765"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"5768","type":"Grid"},{"attributes":{"axis":{"id":"5761"},"coordinates":null,"group":null,"ticker":null},"id":"5764","type":"Grid"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"5747","type":"DatetimeTickFormatter"},{"attributes":{},"id":"5789","type":"UnionRenderers"},{"attributes":{"bottom":{"expr":{"id":"5771"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"5772"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5777","type":"VBar"},{"attributes":{"tools":[{"id":"5749"}]},"id":"5769","type":"Toolbar"},{"attributes":{"coordinates":null,"data_source":{"id":"5805"},"glyph":{"id":"5807"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"5809"},"name":"Internal","nonselection_glyph":{"id":"5808"},"view":{"id":"5811"}},"id":"5810","type":"GlyphRenderer"},{"attributes":{"bottom":{"expr":{"id":"5773"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"5774"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5809","type":"VBar"},{"attributes":{"fields":[]},"id":"5771","type":"Stack"},{"attributes":{"below":[{"id":"5761"}],"center":[{"id":"5764"},{"id":"5768"},{"id":"5803"}],"height":200,"left":[{"id":"5765"}],"renderers":[{"id":"5780"},{"id":"5810"}],"sizing_mode":"scale_width","title":{"id":"5751"},"toolbar":{"id":"5769"},"width":800,"x_range":{"id":"5753"},"x_scale":{"id":"5757"},"y_range":{"id":"5755"},"y_scale":{"id":"5759"}},"id":"5750","subtype":"Figure","type":"Plot"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"5792","type":"AdaptiveTicker"},{"attributes":{"fields":["External","Internal"]},"id":"5774","type":"Stack"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"5799","type":"MonthsTicker"},{"attributes":{"end":1645142400000.0,"start":1542153600000.0},"id":"5753","type":"Range1d"},{"attributes":{"coordinates":null,"formatter":{"id":"5748"},"group":null,"major_label_policy":{"id":"5785"},"ticker":{"id":"5766"}},"id":"5765","type":"LinearAxis"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"5804"},{"id":"5835"}],"location":"top_left"},"id":"5803","type":"Legend"},{"attributes":{},"id":"5759","type":"LinearScale"},{"attributes":{"end":3.3000000000000003},"id":"5755","type":"Range1d"},{"attributes":{"coordinates":null,"formatter":{"id":"5747"},"group":null,"major_label_policy":{"id":"5788"},"ticker":{"id":"5762"}},"id":"5761","type":"DatetimeAxis"},{"attributes":{"source":{"id":"5805"}},"id":"5811","type":"CDSView"},{"attributes":{"coordinates":null,"data_source":{"id":"5775"},"glyph":{"id":"5777"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"5779"},"name":"External","nonselection_glyph":{"id":"5778"},"view":{"id":"5781"}},"id":"5780","type":"GlyphRenderer"},{"attributes":{},"id":"5790","type":"Selection"},{"attributes":{},"id":"5821","type":"UnionRenderers"},{"attributes":{"coordinates":null,"group":null,"text":"Number of Contributors","text_font_size":"1rem"},"id":"5751","type":"Title"},{"attributes":{"label":{"value":"Internal"},"renderers":[{"id":"5810"}]},"id":"5835","type":"LegendItem"},{"attributes":{"months":[0,4,8]},"id":"5800","type":"MonthsTicker"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Contributors","@$name"],["Date","@month{%b %Y}"]]},"id":"5749","type":"HoverTool"},{"attributes":{"label":{"value":"External"},"renderers":[{"id":"5780"}]},"id":"5804","type":"LegendItem"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"5798","type":"MonthsTicker"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"5791"},{"id":"5792"},{"id":"5793"},{"id":"5794"},{"id":"5795"},{"id":"5796"},{"id":"5797"},{"id":"5798"},{"id":"5799"},{"id":"5800"},{"id":"5801"},{"id":"5802"}]},"id":"5762","type":"DatetimeTicker"},{"attributes":{},"id":"5802","type":"YearsTicker"},{"attributes":{"source":{"id":"5775"}},"id":"5781","type":"CDSView"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"5795","type":"DaysTicker"},{"attributes":{},"id":"5785","type":"AllLabels"},{"attributes":{"format":"%6.1u"},"id":"5748","type":"PrintfTickFormatter"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"5793","type":"AdaptiveTicker"}],"root_ids":["5750"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('6111').textContent;
                   const render_items = [{"docid":"37f81fcd-b218-478f-8234-b86a5722136a","root_ids":["5750"],"roots":{"5750":"44d32dcc-fbf4-49ea-a1aa-f1f3a2152f33"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/ecgtools-downloads.html
+++ b/images/metrics/ecgtools-downloads.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="b60be7ce-0c2b-47d5-bc61-063d75f57177" data-root-id="2830"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="3191">
           {"b13ac920-6330-4fa3-b95f-6fc016a47c13":{"defs":[],"roots":{"references":[{"attributes":{"bottom":{"expr":{"id":"2853"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"2854"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2889","type":"VBar"},{"attributes":{},"id":"2870","type":"Selection"},{"attributes":{"label":{"value":"PyPI"},"renderers":[{"id":"2860"}]},"id":"2884","type":"LegendItem"},{"attributes":{"bottom":{"expr":{"id":"2853"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"2854"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2888","type":"VBar"},{"attributes":{},"id":"2868","type":"AllLabels"},{"attributes":{},"id":"2837","type":"LinearScale"},{"attributes":{"months":[0,4,8]},"id":"2880","type":"MonthsTicker"},{"attributes":{"axis":{"id":"2841"},"coordinates":null,"group":null,"ticker":null},"id":"2844","type":"Grid"},{"attributes":{"format":"%6.1u"},"id":"2828","type":"PrintfTickFormatter"},{"attributes":{"days":[1,15]},"id":"2877","type":"DaysTicker"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"2827","type":"DatetimeTickFormatter"},{"attributes":{"bottom":{"expr":{"id":"2853"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"2854"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2887","type":"VBar"},{"attributes":{"coordinates":null,"formatter":{"id":"2827"},"group":null,"major_label_policy":{"id":"2868"},"ticker":{"id":"2842"}},"id":"2841","type":"DatetimeAxis"},{"attributes":{"fields":["PyPI"]},"id":"2853","type":"Stack"},{"attributes":{"axis":{"id":"2845"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"2848","type":"Grid"},{"attributes":{"label":{"value":"Conda"},"renderers":[{"id":"2890"}]},"id":"2915","type":"LegendItem"},{"attributes":{"tools":[{"id":"2829"}]},"id":"2849","type":"Toolbar"},{"attributes":{"data":{"Conda":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,126,129,62,59,0,0],"PyPI":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,599,342,229,794,341,431,353,437,241],"month":[1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"2902"},"selection_policy":{"id":"2901"}},"id":"2885","type":"ColumnDataSource"},{"attributes":{},"id":"2869","type":"UnionRenderers"},{"attributes":{},"id":"2882","type":"YearsTicker"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"2874","type":"DaysTicker"},{"attributes":{},"id":"2846","type":"BasicTicker"},{"attributes":{},"id":"2901","type":"UnionRenderers"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"2872","type":"AdaptiveTicker"},{"attributes":{"fields":[]},"id":"2851","type":"Stack"},{"attributes":{"bottom":{"expr":{"id":"2851"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"2852"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2857","type":"VBar"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"2879","type":"MonthsTicker"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"2871","type":"AdaptiveTicker"},{"attributes":{"end":1645142400000.0,"start":1547510400000.0},"id":"2833","type":"Range1d"},{"attributes":{"source":{"id":"2855"}},"id":"2861","type":"CDSView"},{"attributes":{},"id":"2839","type":"LinearScale"},{"attributes":{"below":[{"id":"2841"}],"center":[{"id":"2844"},{"id":"2848"},{"id":"2883"}],"height":200,"left":[{"id":"2845"}],"renderers":[{"id":"2860"},{"id":"2890"}],"sizing_mode":"scale_width","title":{"id":"2831"},"toolbar":{"id":"2849"},"width":800,"x_range":{"id":"2833"},"x_scale":{"id":"2837"},"y_range":{"id":"2835"},"y_scale":{"id":"2839"}},"id":"2830","subtype":"Figure","type":"Plot"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Downloads","@$name"],["Date","@month{%b %Y}"]]},"id":"2829","type":"HoverTool"},{"attributes":{"coordinates":null,"formatter":{"id":"2828"},"group":null,"major_label_policy":{"id":"2865"},"ticker":{"id":"2846"}},"id":"2845","type":"LinearAxis"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"2871"},{"id":"2872"},{"id":"2873"},{"id":"2874"},{"id":"2875"},{"id":"2876"},{"id":"2877"},{"id":"2878"},{"id":"2879"},{"id":"2880"},{"id":"2881"},{"id":"2882"}]},"id":"2842","type":"DatetimeTicker"},{"attributes":{"bottom":{"expr":{"id":"2851"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"2852"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2858","type":"VBar"},{"attributes":{"coordinates":null,"group":null,"text":"Package Downloads","text_font_size":"1rem"},"id":"2831","type":"Title"},{"attributes":{"coordinates":null,"data_source":{"id":"2855"},"glyph":{"id":"2857"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"2859"},"name":"PyPI","nonselection_glyph":{"id":"2858"},"view":{"id":"2861"}},"id":"2860","type":"GlyphRenderer"},{"attributes":{"fields":["PyPI"]},"id":"2852","type":"Stack"},{"attributes":{"months":[0,6]},"id":"2881","type":"MonthsTicker"},{"attributes":{"end":1012.0000000000001},"id":"2835","type":"Range1d"},{"attributes":{"source":{"id":"2885"}},"id":"2891","type":"CDSView"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"2884"},{"id":"2915"}],"location":"top_left"},"id":"2883","type":"Legend"},{"attributes":{},"id":"2865","type":"AllLabels"},{"attributes":{},"id":"2902","type":"Selection"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"2875","type":"DaysTicker"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"2878","type":"MonthsTicker"},{"attributes":{"bottom":{"expr":{"id":"2851"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"2852"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2859","type":"VBar"},{"attributes":{"days":[1,8,15,22]},"id":"2876","type":"DaysTicker"},{"attributes":{"data":{"Conda":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,126,129,62,59,0,0],"PyPI":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,599,342,229,794,341,431,353,437,241],"month":[1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"2870"},"selection_policy":{"id":"2869"}},"id":"2855","type":"ColumnDataSource"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"2873","type":"AdaptiveTicker"},{"attributes":{"fields":["PyPI","Conda"]},"id":"2854","type":"Stack"},{"attributes":{"coordinates":null,"data_source":{"id":"2885"},"glyph":{"id":"2887"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"2889"},"name":"Conda","nonselection_glyph":{"id":"2888"},"view":{"id":"2891"}},"id":"2890","type":"GlyphRenderer"}],"root_ids":["2830"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('3191').textContent;
                   const render_items = [{"docid":"b13ac920-6330-4fa3-b95f-6fc016a47c13","root_ids":["2830"],"roots":{"2830":"b60be7ce-0c2b-47d5-bc61-063d75f57177"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/intake-esm-burndown.html
+++ b/images/metrics/intake-esm-burndown.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="1cd6f303-1274-4a92-8583-322fba10c1b8" data-root-id="8588"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="8867">
           {"68ba7626-a772-44a0-8e30-42335507a6ba":{"defs":[],"roots":{"references":[{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"8631","type":"DaysTicker"},{"attributes":{"days":[1,8,15,22]},"id":"8632","type":"DaysTicker"},{"attributes":{"bottom":{"expr":{"id":"8609"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"8610"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"8615","type":"VBar"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"8635","type":"MonthsTicker"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"8634","type":"MonthsTicker"},{"attributes":{"tools":[{"id":"8587"}]},"id":"8607","type":"Toolbar"},{"attributes":{"data":{"month":[1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0],"nopen":[0,7,8,8,13,12,14,7,8,22,18,16,18,19,19,23,20,20,24,19,18,17,10,11,11,13,12,15,16,18,18,22,22,26,25,19,19]},"selected":{"id":"8626"},"selection_policy":{"id":"8625"}},"id":"8611","type":"ColumnDataSource"},{"attributes":{"format":"%6.1u"},"id":"8586","type":"PrintfTickFormatter"},{"attributes":{"fields":[]},"id":"8609","type":"Stack"},{"attributes":{"days":[1,15]},"id":"8633","type":"DaysTicker"},{"attributes":{"bottom":{"expr":{"id":"8609"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"8610"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"8614","type":"VBar"},{"attributes":{},"id":"8595","type":"LinearScale"},{"attributes":{"months":[0,4,8]},"id":"8636","type":"MonthsTicker"},{"attributes":{"axis":{"id":"8599"},"coordinates":null,"group":null,"ticker":null},"id":"8602","type":"Grid"},{"attributes":{},"id":"8626","type":"Selection"},{"attributes":{"coordinates":null,"formatter":{"id":"8586"},"group":null,"major_label_policy":{"id":"8622"},"ticker":{"id":"8604"}},"id":"8603","type":"LinearAxis"},{"attributes":{"end":28.6},"id":"8593","type":"Range1d"},{"attributes":{"fields":["nopen"]},"id":"8610","type":"Stack"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"8629","type":"AdaptiveTicker"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"8585","type":"DatetimeTickFormatter"},{"attributes":{"coordinates":null,"group":null,"text":"Open Issues","text_font_size":"1rem"},"id":"8589","type":"Title"},{"attributes":{"months":[0,6]},"id":"8637","type":"MonthsTicker"},{"attributes":{},"id":"8638","type":"YearsTicker"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"8627","type":"AdaptiveTicker"},{"attributes":{"end":1642464000000.0,"start":1544832000000.0},"id":"8591","type":"Range1d"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"8630","type":"DaysTicker"},{"attributes":{"source":{"id":"8611"}},"id":"8617","type":"CDSView"},{"attributes":{},"id":"8625","type":"UnionRenderers"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Issues","@$name"],["Date","@month{%b %Y}"]]},"id":"8587","type":"HoverTool"},{"attributes":{"below":[{"id":"8599"}],"center":[{"id":"8602"},{"id":"8606"}],"height":200,"left":[{"id":"8603"}],"renderers":[{"id":"8616"}],"sizing_mode":"scale_width","title":{"id":"8589"},"toolbar":{"id":"8607"},"width":800,"x_range":{"id":"8591"},"x_scale":{"id":"8595"},"y_range":{"id":"8593"},"y_scale":{"id":"8597"}},"id":"8588","subtype":"Figure","type":"Plot"},{"attributes":{"axis":{"id":"8603"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"8606","type":"Grid"},{"attributes":{},"id":"8624","type":"AllLabels"},{"attributes":{"bottom":{"expr":{"id":"8609"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"8610"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"8613","type":"VBar"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"8628","type":"AdaptiveTicker"},{"attributes":{},"id":"8622","type":"AllLabels"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"8627"},{"id":"8628"},{"id":"8629"},{"id":"8630"},{"id":"8631"},{"id":"8632"},{"id":"8633"},{"id":"8634"},{"id":"8635"},{"id":"8636"},{"id":"8637"},{"id":"8638"}]},"id":"8600","type":"DatetimeTicker"},{"attributes":{"coordinates":null,"formatter":{"id":"8585"},"group":null,"major_label_policy":{"id":"8624"},"ticker":{"id":"8600"}},"id":"8599","type":"DatetimeAxis"},{"attributes":{},"id":"8604","type":"BasicTicker"},{"attributes":{"coordinates":null,"data_source":{"id":"8611"},"glyph":{"id":"8613"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"8615"},"name":"nopen","nonselection_glyph":{"id":"8614"},"view":{"id":"8617"}},"id":"8616","type":"GlyphRenderer"},{"attributes":{},"id":"8597","type":"LinearScale"}],"root_ids":["8588"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('8867').textContent;
                   const render_items = [{"docid":"68ba7626-a772-44a0-8e30-42335507a6ba","root_ids":["8588"],"roots":{"8588":"1cd6f303-1274-4a92-8583-322fba10c1b8"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/intake-esm-commits.html
+++ b/images/metrics/intake-esm-commits.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="b939fb56-a07e-42b5-904c-9ca0934feda1" data-root-id="3195"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="3556">
           {"781e32c8-719c-45fc-9225-a7eb0bddd156":{"defs":[],"roots":{"references":[{"attributes":{},"id":"3204","type":"LinearScale"},{"attributes":{"tools":[{"id":"3194"}]},"id":"3214","type":"Toolbar"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"3236"},{"id":"3237"},{"id":"3238"},{"id":"3239"},{"id":"3240"},{"id":"3241"},{"id":"3242"},{"id":"3243"},{"id":"3244"},{"id":"3245"},{"id":"3246"},{"id":"3247"}]},"id":"3207","type":"DatetimeTicker"},{"attributes":{"axis":{"id":"3210"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"3213","type":"Grid"},{"attributes":{},"id":"3235","type":"Selection"},{"attributes":{"coordinates":null,"formatter":{"id":"3192"},"group":null,"major_label_policy":{"id":"3233"},"ticker":{"id":"3207"}},"id":"3206","type":"DatetimeAxis"},{"attributes":{"below":[{"id":"3206"}],"center":[{"id":"3209"},{"id":"3213"},{"id":"3248"}],"height":200,"left":[{"id":"3210"}],"renderers":[{"id":"3225"},{"id":"3255"}],"sizing_mode":"scale_width","title":{"id":"3196"},"toolbar":{"id":"3214"},"width":800,"x_range":{"id":"3198"},"x_scale":{"id":"3202"},"y_range":{"id":"3200"},"y_scale":{"id":"3204"}},"id":"3195","subtype":"Figure","type":"Plot"},{"attributes":{"axis":{"id":"3206"},"coordinates":null,"group":null,"ticker":null},"id":"3209","type":"Grid"},{"attributes":{},"id":"3202","type":"LinearScale"},{"attributes":{"fields":["External","Internal"]},"id":"3219","type":"Stack"},{"attributes":{"end":459443.60000000003},"id":"3200","type":"Range1d"},{"attributes":{"coordinates":null,"formatter":{"id":"3193"},"group":null,"major_label_policy":{"id":"3230"},"ticker":{"id":"3211"}},"id":"3210","type":"LinearAxis"},{"attributes":{},"id":"3266","type":"UnionRenderers"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Commits","@$name"],["Date","@month{%b %Y}"]]},"id":"3194","type":"HoverTool"},{"attributes":{"data":{"External":[0,0,0,0,1141,0,0,893,45,0,588,165,0,203,0,0,0,0,0,0,4,0,0,0,8,0,0,0,0,0,0,0,0,0,0,78,105,65,139],"Internal":[7396,337249,371801,32555,40597,358052,15522,4449,41582,1336,417088,1933,9055,599,0,7928,884,3571,1559,25,5320,257,2315,7978,80,85,44,4732,0,84,0,22,324,0,4800,167,9941,53,26],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"3267"},"selection_policy":{"id":"3266"}},"id":"3250","type":"ColumnDataSource"},{"attributes":{},"id":"3211","type":"BasicTicker"},{"attributes":{"end":1645142400000.0,"start":1542153600000.0},"id":"3198","type":"Range1d"},{"attributes":{"data":{"External":[0,0,0,0,1141,0,0,893,45,0,588,165,0,203,0,0,0,0,0,0,4,0,0,0,8,0,0,0,0,0,0,0,0,0,0,78,105,65,139],"Internal":[7396,337249,371801,32555,40597,358052,15522,4449,41582,1336,417088,1933,9055,599,0,7928,884,3571,1559,25,5320,257,2315,7978,80,85,44,4732,0,84,0,22,324,0,4800,167,9941,53,26],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"3235"},"selection_policy":{"id":"3234"}},"id":"3220","type":"ColumnDataSource"},{"attributes":{"label":{"value":"Internal"},"renderers":[{"id":"3255"}]},"id":"3280","type":"LegendItem"},{"attributes":{"bottom":{"expr":{"id":"3218"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"3219"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3252","type":"VBar"},{"attributes":{"label":{"value":"External"},"renderers":[{"id":"3225"}]},"id":"3249","type":"LegendItem"},{"attributes":{"format":"%6.1u"},"id":"3193","type":"PrintfTickFormatter"},{"attributes":{"coordinates":null,"data_source":{"id":"3250"},"glyph":{"id":"3252"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"3254"},"name":"Internal","nonselection_glyph":{"id":"3253"},"view":{"id":"3256"}},"id":"3255","type":"GlyphRenderer"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"3236","type":"AdaptiveTicker"},{"attributes":{},"id":"3230","type":"AllLabels"},{"attributes":{"bottom":{"expr":{"id":"3216"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"3217"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3223","type":"VBar"},{"attributes":{},"id":"3267","type":"Selection"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"3237","type":"AdaptiveTicker"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"3238","type":"AdaptiveTicker"},{"attributes":{},"id":"3247","type":"YearsTicker"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"3243","type":"MonthsTicker"},{"attributes":{"coordinates":null,"data_source":{"id":"3220"},"glyph":{"id":"3222"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"3224"},"name":"External","nonselection_glyph":{"id":"3223"},"view":{"id":"3226"}},"id":"3225","type":"GlyphRenderer"},{"attributes":{"source":{"id":"3250"}},"id":"3256","type":"CDSView"},{"attributes":{"days":[1,15]},"id":"3242","type":"DaysTicker"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"3239","type":"DaysTicker"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"3192","type":"DatetimeTickFormatter"},{"attributes":{},"id":"3233","type":"AllLabels"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"3240","type":"DaysTicker"},{"attributes":{"days":[1,8,15,22]},"id":"3241","type":"DaysTicker"},{"attributes":{"coordinates":null,"group":null,"text":"Repository Commits","text_font_size":"1rem"},"id":"3196","type":"Title"},{"attributes":{"months":[0,6]},"id":"3246","type":"MonthsTicker"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"3244","type":"MonthsTicker"},{"attributes":{"source":{"id":"3220"}},"id":"3226","type":"CDSView"},{"attributes":{"months":[0,4,8]},"id":"3245","type":"MonthsTicker"},{"attributes":{"bottom":{"expr":{"id":"3216"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"3217"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3224","type":"VBar"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"3249"},{"id":"3280"}],"location":"top_left"},"id":"3248","type":"Legend"},{"attributes":{"bottom":{"expr":{"id":"3216"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"3217"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3222","type":"VBar"},{"attributes":{"fields":[]},"id":"3216","type":"Stack"},{"attributes":{"bottom":{"expr":{"id":"3218"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"3219"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3253","type":"VBar"},{"attributes":{"bottom":{"expr":{"id":"3218"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"3219"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3254","type":"VBar"},{"attributes":{"fields":["External"]},"id":"3217","type":"Stack"},{"attributes":{"fields":["External"]},"id":"3218","type":"Stack"},{"attributes":{},"id":"3234","type":"UnionRenderers"}],"root_ids":["3195"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('3556').textContent;
                   const render_items = [{"docid":"781e32c8-719c-45fc-9225-a7eb0bddd156","root_ids":["3195"],"roots":{"3195":"b939fb56-a07e-42b5-904c-9ca0934feda1"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/intake-esm-contributors.html
+++ b/images/metrics/intake-esm-contributors.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="d235a3d4-291d-4e3c-b399-6a677817b837" data-root-id="6115"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="6476">
           {"68f23f1a-77d0-4bbb-9035-73e4fae48849":{"defs":[],"roots":{"references":[{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"6160","type":"DaysTicker"},{"attributes":{"coordinates":null,"data_source":{"id":"6170"},"glyph":{"id":"6172"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"6174"},"name":"Internal","nonselection_glyph":{"id":"6173"},"view":{"id":"6176"}},"id":"6175","type":"GlyphRenderer"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"6163","type":"MonthsTicker"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"6157","type":"AdaptiveTicker"},{"attributes":{},"id":"6124","type":"LinearScale"},{"attributes":{"label":{"value":"Internal"},"renderers":[{"id":"6175"}]},"id":"6200","type":"LegendItem"},{"attributes":{"coordinates":null,"formatter":{"id":"6112"},"group":null,"major_label_policy":{"id":"6153"},"ticker":{"id":"6127"}},"id":"6126","type":"DatetimeAxis"},{"attributes":{"end":1645142400000.0,"start":1542153600000.0},"id":"6118","type":"Range1d"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Contributors","@$name"],["Date","@month{%b %Y}"]]},"id":"6114","type":"HoverTool"},{"attributes":{},"id":"6122","type":"LinearScale"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"6156","type":"AdaptiveTicker"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"6164","type":"MonthsTicker"},{"attributes":{"coordinates":null,"group":null,"text":"Number of Contributors","text_font_size":"1rem"},"id":"6116","type":"Title"},{"attributes":{"source":{"id":"6170"}},"id":"6176","type":"CDSView"},{"attributes":{},"id":"6155","type":"Selection"},{"attributes":{"bottom":{"expr":{"id":"6136"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"6137"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6143","type":"VBar"},{"attributes":{},"id":"6186","type":"UnionRenderers"},{"attributes":{"bottom":{"expr":{"id":"6138"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"6139"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6174","type":"VBar"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"6156"},{"id":"6157"},{"id":"6158"},{"id":"6159"},{"id":"6160"},{"id":"6161"},{"id":"6162"},{"id":"6163"},{"id":"6164"},{"id":"6165"},{"id":"6166"},{"id":"6167"}]},"id":"6127","type":"DatetimeTicker"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"6112","type":"DatetimeTickFormatter"},{"attributes":{"source":{"id":"6140"}},"id":"6146","type":"CDSView"},{"attributes":{},"id":"6154","type":"UnionRenderers"},{"attributes":{"tools":[{"id":"6114"}]},"id":"6134","type":"Toolbar"},{"attributes":{"bottom":{"expr":{"id":"6138"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"6139"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6172","type":"VBar"},{"attributes":{},"id":"6187","type":"Selection"},{"attributes":{"end":12.100000000000001},"id":"6120","type":"Range1d"},{"attributes":{"label":{"value":"External"},"renderers":[{"id":"6145"}]},"id":"6169","type":"LegendItem"},{"attributes":{"bottom":{"expr":{"id":"6136"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"6137"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6144","type":"VBar"},{"attributes":{"months":[0,6]},"id":"6166","type":"MonthsTicker"},{"attributes":{"data":{"External":[0,0,0,0,1,1,1,1,1,1,2,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,5,6,6,6],"Internal":[1,1,2,2,2,2,2,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,5,5,5,5,5,5,5],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"6155"},"selection_policy":{"id":"6154"}},"id":"6140","type":"ColumnDataSource"},{"attributes":{"data":{"External":[0,0,0,0,1,1,1,1,1,1,2,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,5,6,6,6],"Internal":[1,1,2,2,2,2,2,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,5,5,5,5,5,5,5],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"6187"},"selection_policy":{"id":"6186"}},"id":"6170","type":"ColumnDataSource"},{"attributes":{"fields":[]},"id":"6136","type":"Stack"},{"attributes":{},"id":"6167","type":"YearsTicker"},{"attributes":{},"id":"6131","type":"BasicTicker"},{"attributes":{"format":"%6.1u"},"id":"6113","type":"PrintfTickFormatter"},{"attributes":{},"id":"6150","type":"AllLabels"},{"attributes":{"fields":["External"]},"id":"6138","type":"Stack"},{"attributes":{"bottom":{"expr":{"id":"6136"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"6137"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6142","type":"VBar"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"6158","type":"AdaptiveTicker"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"6159","type":"DaysTicker"},{"attributes":{"fields":["External","Internal"]},"id":"6139","type":"Stack"},{"attributes":{"days":[1,8,15,22]},"id":"6161","type":"DaysTicker"},{"attributes":{"axis":{"id":"6126"},"coordinates":null,"group":null,"ticker":null},"id":"6129","type":"Grid"},{"attributes":{"months":[0,4,8]},"id":"6165","type":"MonthsTicker"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"6169"},{"id":"6200"}],"location":"top_left"},"id":"6168","type":"Legend"},{"attributes":{"coordinates":null,"formatter":{"id":"6113"},"group":null,"major_label_policy":{"id":"6150"},"ticker":{"id":"6131"}},"id":"6130","type":"LinearAxis"},{"attributes":{"axis":{"id":"6130"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"6133","type":"Grid"},{"attributes":{"bottom":{"expr":{"id":"6138"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"6139"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6173","type":"VBar"},{"attributes":{},"id":"6153","type":"AllLabels"},{"attributes":{"coordinates":null,"data_source":{"id":"6140"},"glyph":{"id":"6142"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"6144"},"name":"External","nonselection_glyph":{"id":"6143"},"view":{"id":"6146"}},"id":"6145","type":"GlyphRenderer"},{"attributes":{"days":[1,15]},"id":"6162","type":"DaysTicker"},{"attributes":{"below":[{"id":"6126"}],"center":[{"id":"6129"},{"id":"6133"},{"id":"6168"}],"height":200,"left":[{"id":"6130"}],"renderers":[{"id":"6145"},{"id":"6175"}],"sizing_mode":"scale_width","title":{"id":"6116"},"toolbar":{"id":"6134"},"width":800,"x_range":{"id":"6118"},"x_scale":{"id":"6122"},"y_range":{"id":"6120"},"y_scale":{"id":"6124"}},"id":"6115","subtype":"Figure","type":"Plot"},{"attributes":{"fields":["External"]},"id":"6137","type":"Stack"}],"root_ids":["6115"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('6476').textContent;
                   const render_items = [{"docid":"68f23f1a-77d0-4bbb-9035-73e4fae48849","root_ids":["6115"],"roots":{"6115":"d235a3d4-291d-4e3c-b399-6a677817b837"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/intake-esm-downloads.html
+++ b/images/metrics/intake-esm-downloads.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="53698ffc-fe04-4989-85e6-37251b7b40b5" data-root-id="1370"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="1731">
           {"b0c28e64-16aa-4679-a732-13fc9de9dc5b":{"defs":[],"roots":{"references":[{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"1411","type":"AdaptiveTicker"},{"attributes":{"fields":[]},"id":"1391","type":"Stack"},{"attributes":{},"id":"1441","type":"UnionRenderers"},{"attributes":{"data":{"Conda":[0,34,118,126,109,93,200,538,275,1543,1262,1389,1429,2005,2130,1724,1965,1489,840,792,668,1096,1091,1084,3203,2866,2805,2052,3674,3353,2970,2377,2249,2499,2031,0,0],"PyPI":[327,323,293,1210,708,707,1511,863,1291,952,1245,982,718,2314,1267,3742,2318,1389,2122,1401,1261,1800,1552,1758,1640,1757,1324,1941,1308,1309,1776,1504,1305,1366,1659,1701,1399],"month":[1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"1442"},"selection_policy":{"id":"1441"}},"id":"1425","type":"ColumnDataSource"},{"attributes":{"fields":["PyPI","Conda"]},"id":"1394","type":"Stack"},{"attributes":{"end":6012.6},"id":"1375","type":"Range1d"},{"attributes":{"label":{"value":"Conda"},"renderers":[{"id":"1430"}]},"id":"1455","type":"LegendItem"},{"attributes":{"months":[0,4,8]},"id":"1420","type":"MonthsTicker"},{"attributes":{"bottom":{"expr":{"id":"1393"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"1394"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1427","type":"VBar"},{"attributes":{"coordinates":null,"data_source":{"id":"1425"},"glyph":{"id":"1427"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"1429"},"name":"Conda","nonselection_glyph":{"id":"1428"},"view":{"id":"1431"}},"id":"1430","type":"GlyphRenderer"},{"attributes":{"coordinates":null,"group":null,"text":"Package Downloads","text_font_size":"1rem"},"id":"1371","type":"Title"},{"attributes":{"format":"%6.1u"},"id":"1368","type":"PrintfTickFormatter"},{"attributes":{"coordinates":null,"formatter":{"id":"1367"},"group":null,"major_label_policy":{"id":"1408"},"ticker":{"id":"1382"}},"id":"1381","type":"DatetimeAxis"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Downloads","@$name"],["Date","@month{%b %Y}"]]},"id":"1369","type":"HoverTool"},{"attributes":{},"id":"1379","type":"LinearScale"},{"attributes":{},"id":"1442","type":"Selection"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"1411"},{"id":"1412"},{"id":"1413"},{"id":"1414"},{"id":"1415"},{"id":"1416"},{"id":"1417"},{"id":"1418"},{"id":"1419"},{"id":"1420"},{"id":"1421"},{"id":"1422"}]},"id":"1382","type":"DatetimeTicker"},{"attributes":{"end":1645142400000.0,"start":1547510400000.0},"id":"1373","type":"Range1d"},{"attributes":{"source":{"id":"1425"}},"id":"1431","type":"CDSView"},{"attributes":{},"id":"1405","type":"AllLabels"},{"attributes":{"bottom":{"expr":{"id":"1391"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"1392"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1399","type":"VBar"},{"attributes":{"source":{"id":"1395"}},"id":"1401","type":"CDSView"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"1367","type":"DatetimeTickFormatter"},{"attributes":{"coordinates":null,"data_source":{"id":"1395"},"glyph":{"id":"1397"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"1399"},"name":"PyPI","nonselection_glyph":{"id":"1398"},"view":{"id":"1401"}},"id":"1400","type":"GlyphRenderer"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"1424"},{"id":"1455"}],"location":"top_left"},"id":"1423","type":"Legend"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"1412","type":"AdaptiveTicker"},{"attributes":{"bottom":{"expr":{"id":"1391"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"1392"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1398","type":"VBar"},{"attributes":{},"id":"1408","type":"AllLabels"},{"attributes":{"fields":["PyPI"]},"id":"1393","type":"Stack"},{"attributes":{"tools":[{"id":"1369"}]},"id":"1389","type":"Toolbar"},{"attributes":{"bottom":{"expr":{"id":"1393"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"1394"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1429","type":"VBar"},{"attributes":{"data":{"Conda":[0,34,118,126,109,93,200,538,275,1543,1262,1389,1429,2005,2130,1724,1965,1489,840,792,668,1096,1091,1084,3203,2866,2805,2052,3674,3353,2970,2377,2249,2499,2031,0,0],"PyPI":[327,323,293,1210,708,707,1511,863,1291,952,1245,982,718,2314,1267,3742,2318,1389,2122,1401,1261,1800,1552,1758,1640,1757,1324,1941,1308,1309,1776,1504,1305,1366,1659,1701,1399],"month":[1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"1410"},"selection_policy":{"id":"1409"}},"id":"1395","type":"ColumnDataSource"},{"attributes":{"bottom":{"expr":{"id":"1393"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"1394"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1428","type":"VBar"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"1419","type":"MonthsTicker"},{"attributes":{"months":[0,6]},"id":"1421","type":"MonthsTicker"},{"attributes":{"days":[1,8,15,22]},"id":"1416","type":"DaysTicker"},{"attributes":{"fields":["PyPI"]},"id":"1392","type":"Stack"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"1415","type":"DaysTicker"},{"attributes":{},"id":"1386","type":"BasicTicker"},{"attributes":{},"id":"1410","type":"Selection"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"1414","type":"DaysTicker"},{"attributes":{"label":{"value":"PyPI"},"renderers":[{"id":"1400"}]},"id":"1424","type":"LegendItem"},{"attributes":{"days":[1,15]},"id":"1417","type":"DaysTicker"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"1418","type":"MonthsTicker"},{"attributes":{"below":[{"id":"1381"}],"center":[{"id":"1384"},{"id":"1388"},{"id":"1423"}],"height":200,"left":[{"id":"1385"}],"renderers":[{"id":"1400"},{"id":"1430"}],"sizing_mode":"scale_width","title":{"id":"1371"},"toolbar":{"id":"1389"},"width":800,"x_range":{"id":"1373"},"x_scale":{"id":"1377"},"y_range":{"id":"1375"},"y_scale":{"id":"1379"}},"id":"1370","subtype":"Figure","type":"Plot"},{"attributes":{"axis":{"id":"1385"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"1388","type":"Grid"},{"attributes":{},"id":"1409","type":"UnionRenderers"},{"attributes":{},"id":"1377","type":"LinearScale"},{"attributes":{},"id":"1422","type":"YearsTicker"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"1413","type":"AdaptiveTicker"},{"attributes":{"bottom":{"expr":{"id":"1391"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"1392"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1397","type":"VBar"},{"attributes":{"axis":{"id":"1381"},"coordinates":null,"group":null,"ticker":null},"id":"1384","type":"Grid"},{"attributes":{"coordinates":null,"formatter":{"id":"1368"},"group":null,"major_label_policy":{"id":"1405"},"ticker":{"id":"1386"}},"id":"1385","type":"LinearAxis"}],"root_ids":["1370"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('1731').textContent;
                   const render_items = [{"docid":"b0c28e64-16aa-4679-a732-13fc9de9dc5b","root_ids":["1370"],"roots":{"1370":"53698ffc-fe04-4989-85e6-37251b7b40b5"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/jupyter-forward-burndown.html
+++ b/images/metrics/jupyter-forward-burndown.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="a43c0b02-2a6b-43b5-9e55-fe85da13ebcc" data-root-id="8871"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="9150">
           {"ba43ee3d-effa-4332-9c9a-a6a9f540227c":{"defs":[],"roots":{"references":[{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"8910"},{"id":"8911"},{"id":"8912"},{"id":"8913"},{"id":"8914"},{"id":"8915"},{"id":"8916"},{"id":"8917"},{"id":"8918"},{"id":"8919"},{"id":"8920"},{"id":"8921"}]},"id":"8883","type":"DatetimeTicker"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"8914","type":"DaysTicker"},{"attributes":{"format":"%6.1u"},"id":"8869","type":"PrintfTickFormatter"},{"attributes":{"fields":[]},"id":"8892","type":"Stack"},{"attributes":{"tools":[{"id":"8870"}]},"id":"8890","type":"Toolbar"},{"attributes":{"bottom":{"expr":{"id":"8892"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"8893"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"8897","type":"VBar"},{"attributes":{"days":[1,8,15,22]},"id":"8915","type":"DaysTicker"},{"attributes":{"axis":{"id":"8886"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"8889","type":"Grid"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"8917","type":"MonthsTicker"},{"attributes":{"end":1642464000000.0,"start":1544832000000.0},"id":"8874","type":"Range1d"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"8868","type":"DatetimeTickFormatter"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"8912","type":"AdaptiveTicker"},{"attributes":{},"id":"8907","type":"AllLabels"},{"attributes":{"source":{"id":"8894"}},"id":"8900","type":"CDSView"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"8913","type":"DaysTicker"},{"attributes":{"bottom":{"expr":{"id":"8892"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"8893"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"8896","type":"VBar"},{"attributes":{"data":{"month":[1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0],"nopen":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3,3,3,0,1,1,1,2,4,5,5,6,8,8,9,9,10,10,9]},"selected":{"id":"8909"},"selection_policy":{"id":"8908"}},"id":"8894","type":"ColumnDataSource"},{"attributes":{},"id":"8908","type":"UnionRenderers"},{"attributes":{},"id":"8905","type":"AllLabels"},{"attributes":{},"id":"8887","type":"BasicTicker"},{"attributes":{"months":[0,6]},"id":"8920","type":"MonthsTicker"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"8911","type":"AdaptiveTicker"},{"attributes":{},"id":"8878","type":"LinearScale"},{"attributes":{"coordinates":null,"formatter":{"id":"8869"},"group":null,"major_label_policy":{"id":"8905"},"ticker":{"id":"8887"}},"id":"8886","type":"LinearAxis"},{"attributes":{},"id":"8880","type":"LinearScale"},{"attributes":{"below":[{"id":"8882"}],"center":[{"id":"8885"},{"id":"8889"}],"height":200,"left":[{"id":"8886"}],"renderers":[{"id":"8899"}],"sizing_mode":"scale_width","title":{"id":"8872"},"toolbar":{"id":"8890"},"width":800,"x_range":{"id":"8874"},"x_scale":{"id":"8878"},"y_range":{"id":"8876"},"y_scale":{"id":"8880"}},"id":"8871","subtype":"Figure","type":"Plot"},{"attributes":{},"id":"8909","type":"Selection"},{"attributes":{"fields":["nopen"]},"id":"8893","type":"Stack"},{"attributes":{"coordinates":null,"data_source":{"id":"8894"},"glyph":{"id":"8896"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"8898"},"name":"nopen","nonselection_glyph":{"id":"8897"},"view":{"id":"8900"}},"id":"8899","type":"GlyphRenderer"},{"attributes":{},"id":"8921","type":"YearsTicker"},{"attributes":{"months":[0,4,8]},"id":"8919","type":"MonthsTicker"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"8918","type":"MonthsTicker"},{"attributes":{"coordinates":null,"formatter":{"id":"8868"},"group":null,"major_label_policy":{"id":"8907"},"ticker":{"id":"8883"}},"id":"8882","type":"DatetimeAxis"},{"attributes":{"coordinates":null,"group":null,"text":"Open Issues","text_font_size":"1rem"},"id":"8872","type":"Title"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"8910","type":"AdaptiveTicker"},{"attributes":{"axis":{"id":"8882"},"coordinates":null,"group":null,"ticker":null},"id":"8885","type":"Grid"},{"attributes":{"end":11.0},"id":"8876","type":"Range1d"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Issues","@$name"],["Date","@month{%b %Y}"]]},"id":"8870","type":"HoverTool"},{"attributes":{"bottom":{"expr":{"id":"8892"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"8893"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"8898","type":"VBar"},{"attributes":{"days":[1,15]},"id":"8916","type":"DaysTicker"}],"root_ids":["8871"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('9150').textContent;
                   const render_items = [{"docid":"ba43ee3d-effa-4332-9c9a-a6a9f540227c","root_ids":["8871"],"roots":{"8871":"a43c0b02-2a6b-43b5-9e55-fe85da13ebcc"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/jupyter-forward-commits.html
+++ b/images/metrics/jupyter-forward-commits.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="732a8640-3fb8-4755-85b6-02087c04b5a1" data-root-id="4655"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="5016">
           {"205864d4-2a90-4066-b1ae-12e268ebcaa5":{"defs":[],"roots":{"references":[{"attributes":{"months":[0,2,4,6,8,10]},"id":"4704","type":"MonthsTicker"},{"attributes":{"label":{"value":"External"},"renderers":[{"id":"4685"}]},"id":"4709","type":"LegendItem"},{"attributes":{},"id":"4693","type":"AllLabels"},{"attributes":{},"id":"4694","type":"UnionRenderers"},{"attributes":{"months":[0,4,8]},"id":"4705","type":"MonthsTicker"},{"attributes":{"source":{"id":"4680"}},"id":"4686","type":"CDSView"},{"attributes":{},"id":"4695","type":"Selection"},{"attributes":{"fields":["External"]},"id":"4678","type":"Stack"},{"attributes":{"tools":[{"id":"4654"}]},"id":"4674","type":"Toolbar"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"4652","type":"DatetimeTickFormatter"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32,69,0,11,0,22,0,0,39,4,0,0,0,0,0,0,0,0,0,4],"Internal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2404,106,392,1709,43,81,193,107,140,414,48,0,69,25,8,8,0,0,1100,146],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"4695"},"selection_policy":{"id":"4694"}},"id":"4680","type":"ColumnDataSource"},{"attributes":{"coordinates":null,"formatter":{"id":"4652"},"group":null,"major_label_policy":{"id":"4693"},"ticker":{"id":"4667"}},"id":"4666","type":"DatetimeAxis"},{"attributes":{"end":1645142400000.0,"start":1542153600000.0},"id":"4658","type":"Range1d"},{"attributes":{"coordinates":null,"formatter":{"id":"4653"},"group":null,"major_label_policy":{"id":"4690"},"ticker":{"id":"4671"}},"id":"4670","type":"LinearAxis"},{"attributes":{},"id":"4726","type":"UnionRenderers"},{"attributes":{"end":2679.6000000000004},"id":"4660","type":"Range1d"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,32,69,0,11,0,22,0,0,39,4,0,0,0,0,0,0,0,0,0,4],"Internal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2404,106,392,1709,43,81,193,107,140,414,48,0,69,25,8,8,0,0,1100,146],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"4727"},"selection_policy":{"id":"4726"}},"id":"4710","type":"ColumnDataSource"},{"attributes":{"bottom":{"expr":{"id":"4676"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"4677"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"4684","type":"VBar"},{"attributes":{"coordinates":null,"group":null,"text":"Repository Commits","text_font_size":"1rem"},"id":"4656","type":"Title"},{"attributes":{"label":{"value":"Internal"},"renderers":[{"id":"4715"}]},"id":"4740","type":"LegendItem"},{"attributes":{"days":[1,8,15,22]},"id":"4701","type":"DaysTicker"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"4696"},{"id":"4697"},{"id":"4698"},{"id":"4699"},{"id":"4700"},{"id":"4701"},{"id":"4702"},{"id":"4703"},{"id":"4704"},{"id":"4705"},{"id":"4706"},{"id":"4707"}]},"id":"4667","type":"DatetimeTicker"},{"attributes":{"bottom":{"expr":{"id":"4678"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"4679"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"4712","type":"VBar"},{"attributes":{"below":[{"id":"4666"}],"center":[{"id":"4669"},{"id":"4673"},{"id":"4708"}],"height":200,"left":[{"id":"4670"}],"renderers":[{"id":"4685"},{"id":"4715"}],"sizing_mode":"scale_width","title":{"id":"4656"},"toolbar":{"id":"4674"},"width":800,"x_range":{"id":"4658"},"x_scale":{"id":"4662"},"y_range":{"id":"4660"},"y_scale":{"id":"4664"}},"id":"4655","subtype":"Figure","type":"Plot"},{"attributes":{"coordinates":null,"data_source":{"id":"4680"},"glyph":{"id":"4682"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"4684"},"name":"External","nonselection_glyph":{"id":"4683"},"view":{"id":"4686"}},"id":"4685","type":"GlyphRenderer"},{"attributes":{"months":[0,6]},"id":"4706","type":"MonthsTicker"},{"attributes":{"coordinates":null,"data_source":{"id":"4710"},"glyph":{"id":"4712"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"4714"},"name":"Internal","nonselection_glyph":{"id":"4713"},"view":{"id":"4716"}},"id":"4715","type":"GlyphRenderer"},{"attributes":{"bottom":{"expr":{"id":"4676"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"4677"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"4682","type":"VBar"},{"attributes":{"format":"%6.1u"},"id":"4653","type":"PrintfTickFormatter"},{"attributes":{"bottom":{"expr":{"id":"4676"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"4677"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"4683","type":"VBar"},{"attributes":{},"id":"4690","type":"AllLabels"},{"attributes":{},"id":"4727","type":"Selection"},{"attributes":{"bottom":{"expr":{"id":"4678"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"4679"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"4713","type":"VBar"},{"attributes":{"fields":[]},"id":"4676","type":"Stack"},{"attributes":{},"id":"4671","type":"BasicTicker"},{"attributes":{"source":{"id":"4710"}},"id":"4716","type":"CDSView"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"4696","type":"AdaptiveTicker"},{"attributes":{"axis":{"id":"4666"},"coordinates":null,"group":null,"ticker":null},"id":"4669","type":"Grid"},{"attributes":{},"id":"4662","type":"LinearScale"},{"attributes":{},"id":"4664","type":"LinearScale"},{"attributes":{"fields":["External","Internal"]},"id":"4679","type":"Stack"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"4697","type":"AdaptiveTicker"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"4698","type":"AdaptiveTicker"},{"attributes":{},"id":"4707","type":"YearsTicker"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"4703","type":"MonthsTicker"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Commits","@$name"],["Date","@month{%b %Y}"]]},"id":"4654","type":"HoverTool"},{"attributes":{"days":[1,15]},"id":"4702","type":"DaysTicker"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"4709"},{"id":"4740"}],"location":"top_left"},"id":"4708","type":"Legend"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"4699","type":"DaysTicker"},{"attributes":{"fields":["External"]},"id":"4677","type":"Stack"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"4700","type":"DaysTicker"},{"attributes":{"bottom":{"expr":{"id":"4678"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"4679"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"4714","type":"VBar"},{"attributes":{"axis":{"id":"4670"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"4673","type":"Grid"}],"root_ids":["4655"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('5016').textContent;
                   const render_items = [{"docid":"205864d4-2a90-4066-b1ae-12e268ebcaa5","root_ids":["4655"],"roots":{"4655":"732a8640-3fb8-4755-85b6-02087c04b5a1"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/jupyter-forward-contributors.html
+++ b/images/metrics/jupyter-forward-contributors.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="fa521af8-8185-4f35-b851-2bba3729a88f" data-root-id="6480"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="6841">
           {"a1b9b630-5da4-40ff-9025-3e41417b21ad":{"defs":[],"roots":{"references":[{"attributes":{"bottom":{"expr":{"id":"6503"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"6504"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6538","type":"VBar"},{"attributes":{},"id":"6487","type":"LinearScale"},{"attributes":{"coordinates":null,"data_source":{"id":"6535"},"glyph":{"id":"6537"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"6539"},"name":"Internal","nonselection_glyph":{"id":"6538"},"view":{"id":"6541"}},"id":"6540","type":"GlyphRenderer"},{"attributes":{},"id":"6532","type":"YearsTicker"},{"attributes":{"end":1645142400000.0,"start":1542153600000.0},"id":"6483","type":"Range1d"},{"attributes":{"coordinates":null,"group":null,"text":"Number of Contributors","text_font_size":"1rem"},"id":"6481","type":"Title"},{"attributes":{"bottom":{"expr":{"id":"6503"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"6504"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6539","type":"VBar"},{"attributes":{},"id":"6489","type":"LinearScale"},{"attributes":{"tools":[{"id":"6479"}]},"id":"6499","type":"Toolbar"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"6534"},{"id":"6565"}],"location":"top_left"},"id":"6533","type":"Legend"},{"attributes":{"bottom":{"expr":{"id":"6503"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"6504"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6537","type":"VBar"},{"attributes":{"fields":["External"]},"id":"6502","type":"Stack"},{"attributes":{"axis":{"id":"6495"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"6498","type":"Grid"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"6521"},{"id":"6522"},{"id":"6523"},{"id":"6524"},{"id":"6525"},{"id":"6526"},{"id":"6527"},{"id":"6528"},{"id":"6529"},{"id":"6530"},{"id":"6531"},{"id":"6532"}]},"id":"6492","type":"DatetimeTicker"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"6477","type":"DatetimeTickFormatter"},{"attributes":{"label":{"value":"Internal"},"renderers":[{"id":"6540"}]},"id":"6565","type":"LegendItem"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"6522","type":"AdaptiveTicker"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2,2,2,3],"Internal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"6520"},"selection_policy":{"id":"6519"}},"id":"6505","type":"ColumnDataSource"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2,2,2,3],"Internal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"6552"},"selection_policy":{"id":"6551"}},"id":"6535","type":"ColumnDataSource"},{"attributes":{},"id":"6518","type":"AllLabels"},{"attributes":{"below":[{"id":"6491"}],"center":[{"id":"6494"},{"id":"6498"},{"id":"6533"}],"height":200,"left":[{"id":"6495"}],"renderers":[{"id":"6510"},{"id":"6540"}],"sizing_mode":"scale_width","title":{"id":"6481"},"toolbar":{"id":"6499"},"width":800,"x_range":{"id":"6483"},"x_scale":{"id":"6487"},"y_range":{"id":"6485"},"y_scale":{"id":"6489"}},"id":"6480","subtype":"Figure","type":"Plot"},{"attributes":{"fields":["External","Internal"]},"id":"6504","type":"Stack"},{"attributes":{"bottom":{"expr":{"id":"6501"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"6502"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6507","type":"VBar"},{"attributes":{"bottom":{"expr":{"id":"6501"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"6502"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6509","type":"VBar"},{"attributes":{"coordinates":null,"formatter":{"id":"6477"},"group":null,"major_label_policy":{"id":"6518"},"ticker":{"id":"6492"}},"id":"6491","type":"DatetimeAxis"},{"attributes":{"bottom":{"expr":{"id":"6501"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"6502"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6508","type":"VBar"},{"attributes":{"format":"%6.1u"},"id":"6478","type":"PrintfTickFormatter"},{"attributes":{"label":{"value":"External"},"renderers":[{"id":"6510"}]},"id":"6534","type":"LegendItem"},{"attributes":{},"id":"6551","type":"UnionRenderers"},{"attributes":{"months":[0,6]},"id":"6531","type":"MonthsTicker"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"6525","type":"DaysTicker"},{"attributes":{"days":[1,15]},"id":"6527","type":"DaysTicker"},{"attributes":{},"id":"6519","type":"UnionRenderers"},{"attributes":{"source":{"id":"6535"}},"id":"6541","type":"CDSView"},{"attributes":{"coordinates":null,"formatter":{"id":"6478"},"group":null,"major_label_policy":{"id":"6515"},"ticker":{"id":"6496"}},"id":"6495","type":"LinearAxis"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"6521","type":"AdaptiveTicker"},{"attributes":{"months":[0,4,8]},"id":"6530","type":"MonthsTicker"},{"attributes":{"end":5.5},"id":"6485","type":"Range1d"},{"attributes":{},"id":"6496","type":"BasicTicker"},{"attributes":{"fields":[]},"id":"6501","type":"Stack"},{"attributes":{"fields":["External"]},"id":"6503","type":"Stack"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"6523","type":"AdaptiveTicker"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"6528","type":"MonthsTicker"},{"attributes":{},"id":"6552","type":"Selection"},{"attributes":{"source":{"id":"6505"}},"id":"6511","type":"CDSView"},{"attributes":{},"id":"6520","type":"Selection"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"6529","type":"MonthsTicker"},{"attributes":{"coordinates":null,"data_source":{"id":"6505"},"glyph":{"id":"6507"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"6509"},"name":"External","nonselection_glyph":{"id":"6508"},"view":{"id":"6511"}},"id":"6510","type":"GlyphRenderer"},{"attributes":{"axis":{"id":"6491"},"coordinates":null,"group":null,"ticker":null},"id":"6494","type":"Grid"},{"attributes":{},"id":"6515","type":"AllLabels"},{"attributes":{"days":[1,8,15,22]},"id":"6526","type":"DaysTicker"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Contributors","@$name"],["Date","@month{%b %Y}"]]},"id":"6479","type":"HoverTool"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"6524","type":"DaysTicker"}],"root_ids":["6480"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('6841').textContent;
                   const render_items = [{"docid":"a1b9b630-5da4-40ff-9025-3e41417b21ad","root_ids":["6480"],"roots":{"6480":"fa521af8-8185-4f35-b851-2bba3729a88f"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/jupyter-forward-downloads.html
+++ b/images/metrics/jupyter-forward-downloads.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="58575104-f4c8-4b69-a20d-b65813c4169e" data-root-id="1005"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="1366">
           {"ef68ec90-524e-493e-ae43-588bcdfa138f":{"defs":[],"roots":{"references":[{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"1049","type":"DaysTicker"},{"attributes":{"end":1653.3000000000002},"id":"1010","type":"Range1d"},{"attributes":{"days":[1,8,15,22]},"id":"1051","type":"DaysTicker"},{"attributes":{"bottom":{"expr":{"id":"1026"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"1027"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1032","type":"VBar"},{"attributes":{"bottom":{"expr":{"id":"1026"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"1027"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1033","type":"VBar"},{"attributes":{"days":[1,15]},"id":"1052","type":"DaysTicker"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"1054","type":"MonthsTicker"},{"attributes":{},"id":"1043","type":"AllLabels"},{"attributes":{"axis":{"id":"1020"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"1023","type":"Grid"},{"attributes":{"fields":[]},"id":"1026","type":"Stack"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"1053","type":"MonthsTicker"},{"attributes":{"months":[0,6]},"id":"1056","type":"MonthsTicker"},{"attributes":{},"id":"1057","type":"YearsTicker"},{"attributes":{"coordinates":null,"formatter":{"id":"1002"},"group":null,"major_label_policy":{"id":"1043"},"ticker":{"id":"1017"}},"id":"1016","type":"DatetimeAxis"},{"attributes":{"source":{"id":"1030"}},"id":"1036","type":"CDSView"},{"attributes":{},"id":"1076","type":"UnionRenderers"},{"attributes":{"months":[0,4,8]},"id":"1055","type":"MonthsTicker"},{"attributes":{},"id":"1077","type":"Selection"},{"attributes":{"bottom":{"expr":{"id":"1026"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"1027"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1034","type":"VBar"},{"attributes":{"source":{"id":"1060"}},"id":"1066","type":"CDSView"},{"attributes":{"fields":["PyPI"]},"id":"1027","type":"Stack"},{"attributes":{"label":{"value":"Conda"},"renderers":[{"id":"1065"}]},"id":"1090","type":"LegendItem"},{"attributes":{"coordinates":null,"data_source":{"id":"1060"},"glyph":{"id":"1062"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"1064"},"name":"Conda","nonselection_glyph":{"id":"1063"},"view":{"id":"1066"}},"id":"1065","type":"GlyphRenderer"},{"attributes":{"coordinates":null,"group":null,"text":"Package Downloads","text_font_size":"1rem"},"id":"1006","type":"Title"},{"attributes":{"below":[{"id":"1016"}],"center":[{"id":"1019"},{"id":"1023"},{"id":"1058"}],"height":200,"left":[{"id":"1020"}],"renderers":[{"id":"1035"},{"id":"1065"}],"sizing_mode":"scale_width","title":{"id":"1006"},"toolbar":{"id":"1024"},"width":800,"x_range":{"id":"1008"},"x_scale":{"id":"1012"},"y_range":{"id":"1010"},"y_scale":{"id":"1014"}},"id":"1005","subtype":"Figure","type":"Plot"},{"attributes":{"tools":[{"id":"1004"}]},"id":"1024","type":"Toolbar"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"1046"},{"id":"1047"},{"id":"1048"},{"id":"1049"},{"id":"1050"},{"id":"1051"},{"id":"1052"},{"id":"1053"},{"id":"1054"},{"id":"1055"},{"id":"1056"},{"id":"1057"}]},"id":"1017","type":"DatetimeTicker"},{"attributes":{},"id":"1021","type":"BasicTicker"},{"attributes":{},"id":"1014","type":"LinearScale"},{"attributes":{"coordinates":null,"data_source":{"id":"1030"},"glyph":{"id":"1032"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"1034"},"name":"PyPI","nonselection_glyph":{"id":"1033"},"view":{"id":"1036"}},"id":"1035","type":"GlyphRenderer"},{"attributes":{"label":{"value":"PyPI"},"renderers":[{"id":"1035"}]},"id":"1059","type":"LegendItem"},{"attributes":{"fields":["PyPI","Conda"]},"id":"1029","type":"Stack"},{"attributes":{"coordinates":null,"formatter":{"id":"1003"},"group":null,"major_label_policy":{"id":"1040"},"ticker":{"id":"1021"}},"id":"1020","type":"LinearAxis"},{"attributes":{"fields":["PyPI"]},"id":"1028","type":"Stack"},{"attributes":{},"id":"1040","type":"AllLabels"},{"attributes":{"bottom":{"expr":{"id":"1028"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"1029"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1064","type":"VBar"},{"attributes":{"end":1645142400000.0,"start":1547510400000.0},"id":"1008","type":"Range1d"},{"attributes":{},"id":"1045","type":"Selection"},{"attributes":{"bottom":{"expr":{"id":"1028"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"1029"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1063","type":"VBar"},{"attributes":{"data":{"Conda":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,53,79,23,127,373,339,243,242,299,534,309,359,199,201,0,0],"PyPI":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,873,532,709,394,754,1058,825,982,654,790,969,672,462,486,635,997,548],"month":[1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"1077"},"selection_policy":{"id":"1076"}},"id":"1060","type":"ColumnDataSource"},{"attributes":{"format":"%6.1u"},"id":"1003","type":"PrintfTickFormatter"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"1050","type":"DaysTicker"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"1002","type":"DatetimeTickFormatter"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Downloads","@$name"],["Date","@month{%b %Y}"]]},"id":"1004","type":"HoverTool"},{"attributes":{"bottom":{"expr":{"id":"1028"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"1029"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1062","type":"VBar"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"1046","type":"AdaptiveTicker"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"1047","type":"AdaptiveTicker"},{"attributes":{},"id":"1044","type":"UnionRenderers"},{"attributes":{"data":{"Conda":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,53,79,23,127,373,339,243,242,299,534,309,359,199,201,0,0],"PyPI":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,873,532,709,394,754,1058,825,982,654,790,969,672,462,486,635,997,548],"month":[1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"1045"},"selection_policy":{"id":"1044"}},"id":"1030","type":"ColumnDataSource"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"1059"},{"id":"1090"}],"location":"top_left"},"id":"1058","type":"Legend"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"1048","type":"AdaptiveTicker"},{"attributes":{"axis":{"id":"1016"},"coordinates":null,"group":null,"ticker":null},"id":"1019","type":"Grid"},{"attributes":{},"id":"1012","type":"LinearScale"}],"root_ids":["1005"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('1366').textContent;
                   const render_items = [{"docid":"ef68ec90-524e-493e-ae43-588bcdfa138f","root_ids":["1005"],"roots":{"1005":"58575104-f4c8-4b69-a20d-b65813c4169e"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/ncar-jobqueue-burndown.html
+++ b/images/metrics/ncar-jobqueue-burndown.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="f5a702e4-76c9-4899-bc2f-861ce66bb920" data-root-id="9154"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="9433">
           {"01e03b95-2928-4513-83d6-2a499de0ccb1":{"defs":[],"roots":{"references":[{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Issues","@$name"],["Date","@month{%b %Y}"]]},"id":"9153","type":"HoverTool"},{"attributes":{},"id":"9188","type":"AllLabels"},{"attributes":{"end":5.5},"id":"9159","type":"Range1d"},{"attributes":{"below":[{"id":"9165"}],"center":[{"id":"9168"},{"id":"9172"}],"height":200,"left":[{"id":"9169"}],"renderers":[{"id":"9182"}],"sizing_mode":"scale_width","title":{"id":"9155"},"toolbar":{"id":"9173"},"width":800,"x_range":{"id":"9157"},"x_scale":{"id":"9161"},"y_range":{"id":"9159"},"y_scale":{"id":"9163"}},"id":"9154","subtype":"Figure","type":"Plot"},{"attributes":{"coordinates":null,"data_source":{"id":"9177"},"glyph":{"id":"9179"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"9181"},"name":"nopen","nonselection_glyph":{"id":"9180"},"view":{"id":"9183"}},"id":"9182","type":"GlyphRenderer"},{"attributes":{"format":"%6.1u"},"id":"9152","type":"PrintfTickFormatter"},{"attributes":{"bottom":{"expr":{"id":"9175"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"9176"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"9181","type":"VBar"},{"attributes":{"fields":[]},"id":"9175","type":"Stack"},{"attributes":{},"id":"9190","type":"AllLabels"},{"attributes":{},"id":"9170","type":"BasicTicker"},{"attributes":{},"id":"9161","type":"LinearScale"},{"attributes":{"end":1642464000000.0,"start":1544832000000.0},"id":"9157","type":"Range1d"},{"attributes":{"tools":[{"id":"9153"}]},"id":"9173","type":"Toolbar"},{"attributes":{"source":{"id":"9177"}},"id":"9183","type":"CDSView"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"9193"},{"id":"9194"},{"id":"9195"},{"id":"9196"},{"id":"9197"},{"id":"9198"},{"id":"9199"},{"id":"9200"},{"id":"9201"},{"id":"9202"},{"id":"9203"},{"id":"9204"}]},"id":"9166","type":"DatetimeTicker"},{"attributes":{"coordinates":null,"formatter":{"id":"9152"},"group":null,"major_label_policy":{"id":"9188"},"ticker":{"id":"9170"}},"id":"9169","type":"LinearAxis"},{"attributes":{"bottom":{"expr":{"id":"9175"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"9176"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"9180","type":"VBar"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"9193","type":"AdaptiveTicker"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"9151","type":"DatetimeTickFormatter"},{"attributes":{},"id":"9163","type":"LinearScale"},{"attributes":{"coordinates":null,"formatter":{"id":"9151"},"group":null,"major_label_policy":{"id":"9190"},"ticker":{"id":"9166"}},"id":"9165","type":"DatetimeAxis"},{"attributes":{"bottom":{"expr":{"id":"9175"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"9176"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"9179","type":"VBar"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"9194","type":"AdaptiveTicker"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"9195","type":"AdaptiveTicker"},{"attributes":{},"id":"9192","type":"Selection"},{"attributes":{},"id":"9204","type":"YearsTicker"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"9200","type":"MonthsTicker"},{"attributes":{"days":[1,15]},"id":"9199","type":"DaysTicker"},{"attributes":{"fields":["nopen"]},"id":"9176","type":"Stack"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"9196","type":"DaysTicker"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"9197","type":"DaysTicker"},{"attributes":{"coordinates":null,"group":null,"text":"Open Issues","text_font_size":"1rem"},"id":"9155","type":"Title"},{"attributes":{"days":[1,8,15,22]},"id":"9198","type":"DaysTicker"},{"attributes":{"months":[0,6]},"id":"9203","type":"MonthsTicker"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"9201","type":"MonthsTicker"},{"attributes":{},"id":"9191","type":"UnionRenderers"},{"attributes":{"months":[0,4,8]},"id":"9202","type":"MonthsTicker"},{"attributes":{"data":{"month":[1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0],"nopen":[0,0,1,1,2,5,3,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,3,3,0,1,0,0,0,0,0,1,1,1,1,1]},"selected":{"id":"9192"},"selection_policy":{"id":"9191"}},"id":"9177","type":"ColumnDataSource"},{"attributes":{"axis":{"id":"9169"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"9172","type":"Grid"},{"attributes":{"axis":{"id":"9165"},"coordinates":null,"group":null,"ticker":null},"id":"9168","type":"Grid"}],"root_ids":["9154"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('9433').textContent;
                   const render_items = [{"docid":"01e03b95-2928-4513-83d6-2a499de0ccb1","root_ids":["9154"],"roots":{"9154":"f5a702e4-76c9-4899-bc2f-861ce66bb920"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/ncar-jobqueue-commits.html
+++ b/images/metrics/ncar-jobqueue-commits.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="f27c6365-b60d-428a-b9ce-340cba1384f4" data-root-id="3560"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="3921">
           {"6228ede0-2034-4289-9e4c-97b6ae7ccea7":{"defs":[],"roots":{"references":[{"attributes":{"coordinates":null,"data_source":{"id":"3585"},"glyph":{"id":"3587"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"3589"},"name":"External","nonselection_glyph":{"id":"3588"},"view":{"id":"3591"}},"id":"3590","type":"GlyphRenderer"},{"attributes":{"fields":["External"]},"id":"3582","type":"Stack"},{"attributes":{"bottom":{"expr":{"id":"3583"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"3584"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3619","type":"VBar"},{"attributes":{"bottom":{"expr":{"id":"3581"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"3582"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3589","type":"VBar"},{"attributes":{},"id":"3599","type":"UnionRenderers"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"3603","type":"AdaptiveTicker"},{"attributes":{"bottom":{"expr":{"id":"3583"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"3584"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3618","type":"VBar"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"3614"},{"id":"3645"}],"location":"top_left"},"id":"3613","type":"Legend"},{"attributes":{"bottom":{"expr":{"id":"3581"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"3582"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3588","type":"VBar"},{"attributes":{},"id":"3567","type":"LinearScale"},{"attributes":{"months":[0,4,8]},"id":"3610","type":"MonthsTicker"},{"attributes":{"source":{"id":"3585"}},"id":"3591","type":"CDSView"},{"attributes":{"fields":[]},"id":"3581","type":"Stack"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"3601","type":"AdaptiveTicker"},{"attributes":{"coordinates":null,"data_source":{"id":"3615"},"glyph":{"id":"3617"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"3619"},"name":"Internal","nonselection_glyph":{"id":"3618"},"view":{"id":"3621"}},"id":"3620","type":"GlyphRenderer"},{"attributes":{"axis":{"id":"3571"},"coordinates":null,"group":null,"ticker":null},"id":"3574","type":"Grid"},{"attributes":{"coordinates":null,"formatter":{"id":"3558"},"group":null,"major_label_policy":{"id":"3595"},"ticker":{"id":"3576"}},"id":"3575","type":"LinearAxis"},{"attributes":{"days":[1,8,15,22]},"id":"3606","type":"DaysTicker"},{"attributes":{"source":{"id":"3615"}},"id":"3621","type":"CDSView"},{"attributes":{"label":{"value":"Internal"},"renderers":[{"id":"3620"}]},"id":"3645","type":"LegendItem"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"3609","type":"MonthsTicker"},{"attributes":{"format":"%6.1u"},"id":"3558","type":"PrintfTickFormatter"},{"attributes":{},"id":"3569","type":"LinearScale"},{"attributes":{},"id":"3631","type":"UnionRenderers"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"3608","type":"MonthsTicker"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"3601"},{"id":"3602"},{"id":"3603"},{"id":"3604"},{"id":"3605"},{"id":"3606"},{"id":"3607"},{"id":"3608"},{"id":"3609"},{"id":"3610"},{"id":"3611"},{"id":"3612"}]},"id":"3572","type":"DatetimeTicker"},{"attributes":{},"id":"3600","type":"Selection"},{"attributes":{"coordinates":null,"formatter":{"id":"3557"},"group":null,"major_label_policy":{"id":"3598"},"ticker":{"id":"3572"}},"id":"3571","type":"DatetimeAxis"},{"attributes":{"bottom":{"expr":{"id":"3581"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"3582"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3587","type":"VBar"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"3604","type":"DaysTicker"},{"attributes":{"fields":["External","Internal"]},"id":"3584","type":"Stack"},{"attributes":{"below":[{"id":"3571"}],"center":[{"id":"3574"},{"id":"3578"},{"id":"3613"}],"height":200,"left":[{"id":"3575"}],"renderers":[{"id":"3590"},{"id":"3620"}],"sizing_mode":"scale_width","title":{"id":"3561"},"toolbar":{"id":"3579"},"width":800,"x_range":{"id":"3563"},"x_scale":{"id":"3567"},"y_range":{"id":"3565"},"y_scale":{"id":"3569"}},"id":"3560","subtype":"Figure","type":"Plot"},{"attributes":{"axis":{"id":"3575"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"3578","type":"Grid"},{"attributes":{"end":1645142400000.0,"start":1542153600000.0},"id":"3563","type":"Range1d"},{"attributes":{},"id":"3598","type":"AllLabels"},{"attributes":{"coordinates":null,"group":null,"text":"Repository Commits","text_font_size":"1rem"},"id":"3561","type":"Title"},{"attributes":{},"id":"3632","type":"Selection"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,2515,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Internal":[0,0,0,5603,0,0,0,2617,652,18,68,0,0,500,0,114,0,0,0,0,0,0,0,852,2,0,172,0,603,0,0,18,0,0,0,0,0,4,0],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"3600"},"selection_policy":{"id":"3599"}},"id":"3585","type":"ColumnDataSource"},{"attributes":{"months":[0,6]},"id":"3611","type":"MonthsTicker"},{"attributes":{},"id":"3576","type":"BasicTicker"},{"attributes":{"label":{"value":"External"},"renderers":[{"id":"3590"}]},"id":"3614","type":"LegendItem"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"3557","type":"DatetimeTickFormatter"},{"attributes":{},"id":"3612","type":"YearsTicker"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Commits","@$name"],["Date","@month{%b %Y}"]]},"id":"3559","type":"HoverTool"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"3602","type":"AdaptiveTicker"},{"attributes":{"tools":[{"id":"3559"}]},"id":"3579","type":"Toolbar"},{"attributes":{"bottom":{"expr":{"id":"3583"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"3584"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3617","type":"VBar"},{"attributes":{"fields":["External"]},"id":"3583","type":"Stack"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"3605","type":"DaysTicker"},{"attributes":{},"id":"3595","type":"AllLabels"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,2515,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Internal":[0,0,0,5603,0,0,0,2617,652,18,68,0,0,500,0,114,0,0,0,0,0,0,0,852,2,0,172,0,603,0,0,18,0,0,0,0,0,4,0],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"3632"},"selection_policy":{"id":"3631"}},"id":"3615","type":"ColumnDataSource"},{"attributes":{"end":6163.3},"id":"3565","type":"Range1d"},{"attributes":{"days":[1,15]},"id":"3607","type":"DaysTicker"}],"root_ids":["3560"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('3921').textContent;
                   const render_items = [{"docid":"6228ede0-2034-4289-9e4c-97b6ae7ccea7","root_ids":["3560"],"roots":{"3560":"f27c6365-b60d-428a-b9ce-340cba1384f4"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/ncar-jobqueue-contributors.html
+++ b/images/metrics/ncar-jobqueue-contributors.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="733fd934-95de-4624-8844-b5845d105b55" data-root-id="6845"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="7206">
           {"9d71ccca-5ae2-446e-8532-f129e8d64465":{"defs":[],"roots":{"references":[{"attributes":{"below":[{"id":"6856"}],"center":[{"id":"6859"},{"id":"6863"},{"id":"6898"}],"height":200,"left":[{"id":"6860"}],"renderers":[{"id":"6875"},{"id":"6905"}],"sizing_mode":"scale_width","title":{"id":"6846"},"toolbar":{"id":"6864"},"width":800,"x_range":{"id":"6848"},"x_scale":{"id":"6852"},"y_range":{"id":"6850"},"y_scale":{"id":"6854"}},"id":"6845","subtype":"Figure","type":"Plot"},{"attributes":{"bottom":{"expr":{"id":"6866"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"6867"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6874","type":"VBar"},{"attributes":{},"id":"6917","type":"Selection"},{"attributes":{},"id":"6916","type":"UnionRenderers"},{"attributes":{"bottom":{"expr":{"id":"6866"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"6867"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6872","type":"VBar"},{"attributes":{"months":[0,4,8]},"id":"6895","type":"MonthsTicker"},{"attributes":{},"id":"6861","type":"BasicTicker"},{"attributes":{"bottom":{"expr":{"id":"6866"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"6867"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6873","type":"VBar"},{"attributes":{},"id":"6884","type":"UnionRenderers"},{"attributes":{"fields":[]},"id":"6866","type":"Stack"},{"attributes":{"axis":{"id":"6860"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"6863","type":"Grid"},{"attributes":{"label":{"value":"External"},"renderers":[{"id":"6875"}]},"id":"6899","type":"LegendItem"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"6893","type":"MonthsTicker"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"6886"},{"id":"6887"},{"id":"6888"},{"id":"6889"},{"id":"6890"},{"id":"6891"},{"id":"6892"},{"id":"6893"},{"id":"6894"},{"id":"6895"},{"id":"6896"},{"id":"6897"}]},"id":"6857","type":"DatetimeTicker"},{"attributes":{"months":[0,6]},"id":"6896","type":"MonthsTicker"},{"attributes":{"end":3.3000000000000003},"id":"6850","type":"Range1d"},{"attributes":{"source":{"id":"6900"}},"id":"6906","type":"CDSView"},{"attributes":{},"id":"6883","type":"AllLabels"},{"attributes":{"coordinates":null,"formatter":{"id":"6842"},"group":null,"major_label_policy":{"id":"6883"},"ticker":{"id":"6857"}},"id":"6856","type":"DatetimeAxis"},{"attributes":{},"id":"6854","type":"LinearScale"},{"attributes":{"tools":[{"id":"6844"}]},"id":"6864","type":"Toolbar"},{"attributes":{"label":{"value":"Internal"},"renderers":[{"id":"6905"}]},"id":"6930","type":"LegendItem"},{"attributes":{"axis":{"id":"6856"},"coordinates":null,"group":null,"ticker":null},"id":"6859","type":"Grid"},{"attributes":{},"id":"6885","type":"Selection"},{"attributes":{"coordinates":null,"group":null,"text":"Number of Contributors","text_font_size":"1rem"},"id":"6846","type":"Title"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"6887","type":"AdaptiveTicker"},{"attributes":{"fields":["External"]},"id":"6867","type":"Stack"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"6889","type":"DaysTicker"},{"attributes":{"end":1645142400000.0,"start":1542153600000.0},"id":"6848","type":"Range1d"},{"attributes":{"days":[1,8,15,22]},"id":"6891","type":"DaysTicker"},{"attributes":{"coordinates":null,"formatter":{"id":"6843"},"group":null,"major_label_policy":{"id":"6880"},"ticker":{"id":"6861"}},"id":"6860","type":"LinearAxis"},{"attributes":{"format":"%6.1u"},"id":"6843","type":"PrintfTickFormatter"},{"attributes":{"fields":["External"]},"id":"6868","type":"Stack"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"6842","type":"DatetimeTickFormatter"},{"attributes":{"fields":["External","Internal"]},"id":"6869","type":"Stack"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"6888","type":"AdaptiveTicker"},{"attributes":{"bottom":{"expr":{"id":"6868"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"6869"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6903","type":"VBar"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"6894","type":"MonthsTicker"},{"attributes":{"days":[1,15]},"id":"6892","type":"DaysTicker"},{"attributes":{"coordinates":null,"data_source":{"id":"6900"},"glyph":{"id":"6902"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"6904"},"name":"Internal","nonselection_glyph":{"id":"6903"},"view":{"id":"6906"}},"id":"6905","type":"GlyphRenderer"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"6890","type":"DaysTicker"},{"attributes":{},"id":"6852","type":"LinearScale"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Internal":[0,0,0,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,3,3],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"6885"},"selection_policy":{"id":"6884"}},"id":"6870","type":"ColumnDataSource"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"6899"},{"id":"6930"}],"location":"top_left"},"id":"6898","type":"Legend"},{"attributes":{"bottom":{"expr":{"id":"6868"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"6869"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6904","type":"VBar"},{"attributes":{"bottom":{"expr":{"id":"6868"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"6869"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"6902","type":"VBar"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Contributors","@$name"],["Date","@month{%b %Y}"]]},"id":"6844","type":"HoverTool"},{"attributes":{},"id":"6897","type":"YearsTicker"},{"attributes":{"source":{"id":"6870"}},"id":"6876","type":"CDSView"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Internal":[0,0,0,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,3,3],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"6917"},"selection_policy":{"id":"6916"}},"id":"6900","type":"ColumnDataSource"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"6886","type":"AdaptiveTicker"},{"attributes":{},"id":"6880","type":"AllLabels"},{"attributes":{"coordinates":null,"data_source":{"id":"6870"},"glyph":{"id":"6872"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"6874"},"name":"External","nonselection_glyph":{"id":"6873"},"view":{"id":"6876"}},"id":"6875","type":"GlyphRenderer"}],"root_ids":["6845"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('7206').textContent;
                   const render_items = [{"docid":"9d71ccca-5ae2-446e-8532-f129e8d64465","root_ids":["6845"],"roots":{"6845":"733fd934-95de-4624-8844-b5845d105b55"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/ncar-jobqueue-downloads.html
+++ b/images/metrics/ncar-jobqueue-downloads.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="7f37b62d-ae6f-4d92-9759-207cbb83d53f" data-root-id="1735"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="2096">
           {"9c1aa206-68da-4c18-847b-589706cf9f3f":{"defs":[],"roots":{"references":[{"attributes":{"below":[{"id":"1746"}],"center":[{"id":"1749"},{"id":"1753"},{"id":"1788"}],"height":200,"left":[{"id":"1750"}],"renderers":[{"id":"1765"},{"id":"1795"}],"sizing_mode":"scale_width","title":{"id":"1736"},"toolbar":{"id":"1754"},"width":800,"x_range":{"id":"1738"},"x_scale":{"id":"1742"},"y_range":{"id":"1740"},"y_scale":{"id":"1744"}},"id":"1735","subtype":"Figure","type":"Plot"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"1776","type":"AdaptiveTicker"},{"attributes":{},"id":"1770","type":"AllLabels"},{"attributes":{"coordinates":null,"data_source":{"id":"1760"},"glyph":{"id":"1762"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"1764"},"name":"PyPI","nonselection_glyph":{"id":"1763"},"view":{"id":"1766"}},"id":"1765","type":"GlyphRenderer"},{"attributes":{"source":{"id":"1790"}},"id":"1796","type":"CDSView"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"1777","type":"AdaptiveTicker"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"1778","type":"AdaptiveTicker"},{"attributes":{},"id":"1742","type":"LinearScale"},{"attributes":{"source":{"id":"1760"}},"id":"1766","type":"CDSView"},{"attributes":{},"id":"1787","type":"YearsTicker"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"1783","type":"MonthsTicker"},{"attributes":{},"id":"1744","type":"LinearScale"},{"attributes":{"days":[1,15]},"id":"1782","type":"DaysTicker"},{"attributes":{},"id":"1773","type":"AllLabels"},{"attributes":{"label":{"value":"Conda"},"renderers":[{"id":"1795"}]},"id":"1820","type":"LegendItem"},{"attributes":{"coordinates":null,"formatter":{"id":"1732"},"group":null,"major_label_policy":{"id":"1773"},"ticker":{"id":"1747"}},"id":"1746","type":"DatetimeAxis"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"1779","type":"DaysTicker"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"1780","type":"DaysTicker"},{"attributes":{},"id":"1751","type":"BasicTicker"},{"attributes":{"days":[1,8,15,22]},"id":"1781","type":"DaysTicker"},{"attributes":{"end":1645142400000.0,"start":1547510400000.0},"id":"1738","type":"Range1d"},{"attributes":{"months":[0,6]},"id":"1786","type":"MonthsTicker"},{"attributes":{},"id":"1807","type":"Selection"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"1784","type":"MonthsTicker"},{"attributes":{"fields":[]},"id":"1756","type":"Stack"},{"attributes":{"end":2062.5},"id":"1740","type":"Range1d"},{"attributes":{},"id":"1806","type":"UnionRenderers"},{"attributes":{"axis":{"id":"1746"},"coordinates":null,"group":null,"ticker":null},"id":"1749","type":"Grid"},{"attributes":{"months":[0,4,8]},"id":"1785","type":"MonthsTicker"},{"attributes":{"coordinates":null,"group":null,"text":"Package Downloads","text_font_size":"1rem"},"id":"1736","type":"Title"},{"attributes":{"label":{"value":"PyPI"},"renderers":[{"id":"1765"}]},"id":"1789","type":"LegendItem"},{"attributes":{"format":"%6.1u"},"id":"1733","type":"PrintfTickFormatter"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"1776"},{"id":"1777"},{"id":"1778"},{"id":"1779"},{"id":"1780"},{"id":"1781"},{"id":"1782"},{"id":"1783"},{"id":"1784"},{"id":"1785"},{"id":"1786"},{"id":"1787"}]},"id":"1747","type":"DatetimeTicker"},{"attributes":{"axis":{"id":"1750"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"1753","type":"Grid"},{"attributes":{},"id":"1774","type":"UnionRenderers"},{"attributes":{"coordinates":null,"formatter":{"id":"1733"},"group":null,"major_label_policy":{"id":"1770"},"ticker":{"id":"1751"}},"id":"1750","type":"LinearAxis"},{"attributes":{},"id":"1775","type":"Selection"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"1789"},{"id":"1820"}],"location":"top_left"},"id":"1788","type":"Legend"},{"attributes":{"fields":["PyPI"]},"id":"1757","type":"Stack"},{"attributes":{"data":{"Conda":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,73,81,41,151,313,494,178,208,289,400,249,271,180,151,0,0],"PyPI":[0,528,184,220,243,201,707,1188,1875,700,732,1778,794,1417,959,817,762,720,1117,964,846,1230,1420,946,1717,1314,1244,958,876,996,980,905,669,671,824,768,554],"month":[1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"1775"},"selection_policy":{"id":"1774"}},"id":"1760","type":"ColumnDataSource"},{"attributes":{"tools":[{"id":"1734"}]},"id":"1754","type":"Toolbar"},{"attributes":{"bottom":{"expr":{"id":"1756"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"1757"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1764","type":"VBar"},{"attributes":{"bottom":{"expr":{"id":"1756"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"1757"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1762","type":"VBar"},{"attributes":{"bottom":{"expr":{"id":"1758"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"1759"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1794","type":"VBar"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"1732","type":"DatetimeTickFormatter"},{"attributes":{"bottom":{"expr":{"id":"1756"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"1757"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1763","type":"VBar"},{"attributes":{"bottom":{"expr":{"id":"1758"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"1759"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1793","type":"VBar"},{"attributes":{"data":{"Conda":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,73,81,41,151,313,494,178,208,289,400,249,271,180,151,0,0],"PyPI":[0,528,184,220,243,201,707,1188,1875,700,732,1778,794,1417,959,817,762,720,1117,964,846,1230,1420,946,1717,1314,1244,958,876,996,980,905,669,671,824,768,554],"month":[1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"1807"},"selection_policy":{"id":"1806"}},"id":"1790","type":"ColumnDataSource"},{"attributes":{"coordinates":null,"data_source":{"id":"1790"},"glyph":{"id":"1792"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"1794"},"name":"Conda","nonselection_glyph":{"id":"1793"},"view":{"id":"1796"}},"id":"1795","type":"GlyphRenderer"},{"attributes":{"bottom":{"expr":{"id":"1758"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"1759"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"1792","type":"VBar"},{"attributes":{"fields":["PyPI","Conda"]},"id":"1759","type":"Stack"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Downloads","@$name"],["Date","@month{%b %Y}"]]},"id":"1734","type":"HoverTool"},{"attributes":{"fields":["PyPI"]},"id":"1758","type":"Stack"}],"root_ids":["1735"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('2096').textContent;
                   const render_items = [{"docid":"9c1aa206-68da-4c18-847b-589706cf9f3f","root_ids":["1735"],"roots":{"1735":"7f37b62d-ae6f-4d92-9759-207cbb83d53f"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/xcollection-burndown.html
+++ b/images/metrics/xcollection-burndown.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="b66e2bb5-b4a7-483d-b1b0-06d1933c2bfb" data-root-id="9720"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="9999">
           {"70678d93-3ea4-41fa-bd54-5a6d2e106a43":{"defs":[],"roots":{"references":[{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"9759","type":"AdaptiveTicker"},{"attributes":{"fields":[]},"id":"9741","type":"Stack"},{"attributes":{"coordinates":null,"formatter":{"id":"9717"},"group":null,"major_label_policy":{"id":"9756"},"ticker":{"id":"9732"}},"id":"9731","type":"DatetimeAxis"},{"attributes":{"tools":[{"id":"9719"}]},"id":"9739","type":"Toolbar"},{"attributes":{"format":"%6.1u"},"id":"9718","type":"PrintfTickFormatter"},{"attributes":{"coordinates":null,"data_source":{"id":"9743"},"glyph":{"id":"9745"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"9747"},"name":"nopen","nonselection_glyph":{"id":"9746"},"view":{"id":"9749"}},"id":"9748","type":"GlyphRenderer"},{"attributes":{},"id":"9770","type":"YearsTicker"},{"attributes":{"coordinates":null,"formatter":{"id":"9718"},"group":null,"major_label_policy":{"id":"9754"},"ticker":{"id":"9736"}},"id":"9735","type":"LinearAxis"},{"attributes":{},"id":"9727","type":"LinearScale"},{"attributes":{"end":1642464000000.0,"start":1544832000000.0},"id":"9723","type":"Range1d"},{"attributes":{"data":{"month":[1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0],"nopen":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,4,8,7,7,7,7]},"selected":{"id":"9758"},"selection_policy":{"id":"9757"}},"id":"9743","type":"ColumnDataSource"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"9760","type":"AdaptiveTicker"},{"attributes":{"below":[{"id":"9731"}],"center":[{"id":"9734"},{"id":"9738"}],"height":200,"left":[{"id":"9735"}],"renderers":[{"id":"9748"}],"sizing_mode":"scale_width","title":{"id":"9721"},"toolbar":{"id":"9739"},"width":800,"x_range":{"id":"9723"},"x_scale":{"id":"9727"},"y_range":{"id":"9725"},"y_scale":{"id":"9729"}},"id":"9720","subtype":"Figure","type":"Plot"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"9761","type":"AdaptiveTicker"},{"attributes":{},"id":"9756","type":"AllLabels"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"9766","type":"MonthsTicker"},{"attributes":{},"id":"9754","type":"AllLabels"},{"attributes":{"months":[0,4,8]},"id":"9768","type":"MonthsTicker"},{"attributes":{"days":[1,15]},"id":"9765","type":"DaysTicker"},{"attributes":{"bottom":{"expr":{"id":"9741"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"9742"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"9747","type":"VBar"},{"attributes":{},"id":"9729","type":"LinearScale"},{"attributes":{"bottom":{"expr":{"id":"9741"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"9742"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"9745","type":"VBar"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Issues","@$name"],["Date","@month{%b %Y}"]]},"id":"9719","type":"HoverTool"},{"attributes":{},"id":"9736","type":"BasicTicker"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"9717","type":"DatetimeTickFormatter"},{"attributes":{"coordinates":null,"group":null,"text":"Open Issues","text_font_size":"1rem"},"id":"9721","type":"Title"},{"attributes":{"source":{"id":"9743"}},"id":"9749","type":"CDSView"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"9767","type":"MonthsTicker"},{"attributes":{"axis":{"id":"9735"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"9738","type":"Grid"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"9763","type":"DaysTicker"},{"attributes":{},"id":"9758","type":"Selection"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"9762","type":"DaysTicker"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"9759"},{"id":"9760"},{"id":"9761"},{"id":"9762"},{"id":"9763"},{"id":"9764"},{"id":"9765"},{"id":"9766"},{"id":"9767"},{"id":"9768"},{"id":"9769"},{"id":"9770"}]},"id":"9732","type":"DatetimeTicker"},{"attributes":{"bottom":{"expr":{"id":"9741"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"9742"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"9746","type":"VBar"},{"attributes":{"axis":{"id":"9731"},"coordinates":null,"group":null,"ticker":null},"id":"9734","type":"Grid"},{"attributes":{},"id":"9757","type":"UnionRenderers"},{"attributes":{"months":[0,6]},"id":"9769","type":"MonthsTicker"},{"attributes":{"days":[1,8,15,22]},"id":"9764","type":"DaysTicker"},{"attributes":{"fields":["nopen"]},"id":"9742","type":"Stack"},{"attributes":{"end":8.8},"id":"9725","type":"Range1d"}],"root_ids":["9720"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('9999').textContent;
                   const render_items = [{"docid":"70678d93-3ea4-41fa-bd54-5a6d2e106a43","root_ids":["9720"],"roots":{"9720":"b66e2bb5-b4a7-483d-b1b0-06d1933c2bfb"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/xcollection-commits.html
+++ b/images/metrics/xcollection-commits.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="396a6299-4c97-48c5-8ae5-6dee1fef4d3d" data-root-id="5020"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="5381">
           {"898ec253-cef8-4259-97cb-75bba40d074c":{"defs":[],"roots":{"references":[{"attributes":{"bottom":{"expr":{"id":"5041"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"5042"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5048","type":"VBar"},{"attributes":{},"id":"5091","type":"UnionRenderers"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Internal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1648,0,133,409,801,319,0],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"5092"},"selection_policy":{"id":"5091"}},"id":"5075","type":"ColumnDataSource"},{"attributes":{},"id":"5029","type":"LinearScale"},{"attributes":{"label":{"value":"Internal"},"renderers":[{"id":"5080"}]},"id":"5105","type":"LegendItem"},{"attributes":{"bottom":{"expr":{"id":"5041"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"5042"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5047","type":"VBar"},{"attributes":{"bottom":{"expr":{"id":"5043"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"5044"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5077","type":"VBar"},{"attributes":{"bottom":{"expr":{"id":"5041"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"5042"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5049","type":"VBar"},{"attributes":{"coordinates":null,"data_source":{"id":"5045"},"glyph":{"id":"5047"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"5049"},"name":"External","nonselection_glyph":{"id":"5048"},"view":{"id":"5051"}},"id":"5050","type":"GlyphRenderer"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"5061","type":"AdaptiveTicker"},{"attributes":{"coordinates":null,"data_source":{"id":"5075"},"glyph":{"id":"5077"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"5079"},"name":"Internal","nonselection_glyph":{"id":"5078"},"view":{"id":"5081"}},"id":"5080","type":"GlyphRenderer"},{"attributes":{"axis":{"id":"5035"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"5038","type":"Grid"},{"attributes":{"axis":{"id":"5031"},"coordinates":null,"group":null,"ticker":null},"id":"5034","type":"Grid"},{"attributes":{},"id":"5055","type":"AllLabels"},{"attributes":{},"id":"5092","type":"Selection"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"5062","type":"AdaptiveTicker"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"5063","type":"AdaptiveTicker"},{"attributes":{},"id":"5072","type":"YearsTicker"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"5068","type":"MonthsTicker"},{"attributes":{"source":{"id":"5075"}},"id":"5081","type":"CDSView"},{"attributes":{"days":[1,15]},"id":"5067","type":"DaysTicker"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"5064","type":"DaysTicker"},{"attributes":{},"id":"5058","type":"AllLabels"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"5065","type":"DaysTicker"},{"attributes":{"days":[1,8,15,22]},"id":"5066","type":"DaysTicker"},{"attributes":{"months":[0,6]},"id":"5071","type":"MonthsTicker"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"5069","type":"MonthsTicker"},{"attributes":{},"id":"5036","type":"BasicTicker"},{"attributes":{"tools":[{"id":"5019"}]},"id":"5039","type":"Toolbar"},{"attributes":{"end":1812.8000000000002},"id":"5025","type":"Range1d"},{"attributes":{"months":[0,4,8]},"id":"5070","type":"MonthsTicker"},{"attributes":{"fields":["External","Internal"]},"id":"5044","type":"Stack"},{"attributes":{"coordinates":null,"formatter":{"id":"5017"},"group":null,"major_label_policy":{"id":"5058"},"ticker":{"id":"5032"}},"id":"5031","type":"DatetimeAxis"},{"attributes":{"bottom":{"expr":{"id":"5043"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"5044"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5079","type":"VBar"},{"attributes":{"bottom":{"expr":{"id":"5043"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"5044"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5078","type":"VBar"},{"attributes":{},"id":"5027","type":"LinearScale"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"5061"},{"id":"5062"},{"id":"5063"},{"id":"5064"},{"id":"5065"},{"id":"5066"},{"id":"5067"},{"id":"5068"},{"id":"5069"},{"id":"5070"},{"id":"5071"},{"id":"5072"}]},"id":"5032","type":"DatetimeTicker"},{"attributes":{},"id":"5059","type":"UnionRenderers"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Internal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1648,0,133,409,801,319,0],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"5060"},"selection_policy":{"id":"5059"}},"id":"5045","type":"ColumnDataSource"},{"attributes":{"fields":["External"]},"id":"5042","type":"Stack"},{"attributes":{"label":{"value":"External"},"renderers":[{"id":"5050"}]},"id":"5074","type":"LegendItem"},{"attributes":{"coordinates":null,"group":null,"text":"Repository Commits","text_font_size":"1rem"},"id":"5021","type":"Title"},{"attributes":{"source":{"id":"5045"}},"id":"5051","type":"CDSView"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Commits","@$name"],["Date","@month{%b %Y}"]]},"id":"5019","type":"HoverTool"},{"attributes":{"below":[{"id":"5031"}],"center":[{"id":"5034"},{"id":"5038"},{"id":"5073"}],"height":200,"left":[{"id":"5035"}],"renderers":[{"id":"5050"},{"id":"5080"}],"sizing_mode":"scale_width","title":{"id":"5021"},"toolbar":{"id":"5039"},"width":800,"x_range":{"id":"5023"},"x_scale":{"id":"5027"},"y_range":{"id":"5025"},"y_scale":{"id":"5029"}},"id":"5020","subtype":"Figure","type":"Plot"},{"attributes":{},"id":"5060","type":"Selection"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"5074"},{"id":"5105"}],"location":"top_left"},"id":"5073","type":"Legend"},{"attributes":{"fields":[]},"id":"5041","type":"Stack"},{"attributes":{"format":"%6.1u"},"id":"5018","type":"PrintfTickFormatter"},{"attributes":{"fields":["External"]},"id":"5043","type":"Stack"},{"attributes":{"end":1645142400000.0,"start":1542153600000.0},"id":"5023","type":"Range1d"},{"attributes":{"coordinates":null,"formatter":{"id":"5018"},"group":null,"major_label_policy":{"id":"5055"},"ticker":{"id":"5036"}},"id":"5035","type":"LinearAxis"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"5017","type":"DatetimeTickFormatter"}],"root_ids":["5020"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('5381').textContent;
                   const render_items = [{"docid":"898ec253-cef8-4259-97cb-75bba40d074c","root_ids":["5020"],"roots":{"5020":"396a6299-4c97-48c5-8ae5-6dee1fef4d3d"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/xcollection-contributors.html
+++ b/images/metrics/xcollection-contributors.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="5891240a-a6b9-44e5-858a-bc0017df8935" data-root-id="7210"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="7571">
           {"217b88de-61d1-4c6e-8abf-f1629cf84a59":{"defs":[],"roots":{"references":[{"attributes":{"coordinates":null,"data_source":{"id":"7235"},"glyph":{"id":"7237"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"7239"},"name":"External","nonselection_glyph":{"id":"7238"},"view":{"id":"7241"}},"id":"7240","type":"GlyphRenderer"},{"attributes":{},"id":"7245","type":"AllLabels"},{"attributes":{},"id":"7226","type":"BasicTicker"},{"attributes":{"axis":{"id":"7221"},"coordinates":null,"group":null,"ticker":null},"id":"7224","type":"Grid"},{"attributes":{},"id":"7281","type":"UnionRenderers"},{"attributes":{"format":"%6.1u"},"id":"7208","type":"PrintfTickFormatter"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Internal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,2,3,3,3,3],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"7250"},"selection_policy":{"id":"7249"}},"id":"7235","type":"ColumnDataSource"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Internal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,2,3,3,3,3],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"7282"},"selection_policy":{"id":"7281"}},"id":"7265","type":"ColumnDataSource"},{"attributes":{},"id":"7249","type":"UnionRenderers"},{"attributes":{"bottom":{"expr":{"id":"7233"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"7234"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7267","type":"VBar"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"7207","type":"DatetimeTickFormatter"},{"attributes":{"bottom":{"expr":{"id":"7231"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"7232"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7238","type":"VBar"},{"attributes":{},"id":"7250","type":"Selection"},{"attributes":{"bottom":{"expr":{"id":"7231"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"7232"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7237","type":"VBar"},{"attributes":{"coordinates":null,"formatter":{"id":"7208"},"group":null,"major_label_policy":{"id":"7245"},"ticker":{"id":"7226"}},"id":"7225","type":"LinearAxis"},{"attributes":{"coordinates":null,"data_source":{"id":"7265"},"glyph":{"id":"7267"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"7269"},"name":"Internal","nonselection_glyph":{"id":"7268"},"view":{"id":"7271"}},"id":"7270","type":"GlyphRenderer"},{"attributes":{"label":{"value":"External"},"renderers":[{"id":"7240"}]},"id":"7264","type":"LegendItem"},{"attributes":{"label":{"value":"Internal"},"renderers":[{"id":"7270"}]},"id":"7295","type":"LegendItem"},{"attributes":{"coordinates":null,"group":null,"text":"Number of Contributors","text_font_size":"1rem"},"id":"7211","type":"Title"},{"attributes":{},"id":"7282","type":"Selection"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"7264"},{"id":"7295"}],"location":"top_left"},"id":"7263","type":"Legend"},{"attributes":{"fields":[]},"id":"7231","type":"Stack"},{"attributes":{"bottom":{"expr":{"id":"7231"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"7232"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7239","type":"VBar"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"7251","type":"AdaptiveTicker"},{"attributes":{"source":{"id":"7265"}},"id":"7271","type":"CDSView"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"7251"},{"id":"7252"},{"id":"7253"},{"id":"7254"},{"id":"7255"},{"id":"7256"},{"id":"7257"},{"id":"7258"},{"id":"7259"},{"id":"7260"},{"id":"7261"},{"id":"7262"}]},"id":"7222","type":"DatetimeTicker"},{"attributes":{"end":1645142400000.0,"start":1542153600000.0},"id":"7213","type":"Range1d"},{"attributes":{"bottom":{"expr":{"id":"7233"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"7234"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7268","type":"VBar"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"7252","type":"AdaptiveTicker"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"7253","type":"AdaptiveTicker"},{"attributes":{"coordinates":null,"formatter":{"id":"7207"},"group":null,"major_label_policy":{"id":"7248"},"ticker":{"id":"7222"}},"id":"7221","type":"DatetimeAxis"},{"attributes":{},"id":"7248","type":"AllLabels"},{"attributes":{},"id":"7262","type":"YearsTicker"},{"attributes":{"fields":["External","Internal"]},"id":"7234","type":"Stack"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"7258","type":"MonthsTicker"},{"attributes":{"days":[1,15]},"id":"7257","type":"DaysTicker"},{"attributes":{"axis":{"id":"7225"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"7228","type":"Grid"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"7254","type":"DaysTicker"},{"attributes":{"fields":["External"]},"id":"7233","type":"Stack"},{"attributes":{"source":{"id":"7235"}},"id":"7241","type":"CDSView"},{"attributes":{"end":3.3000000000000003},"id":"7215","type":"Range1d"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"7255","type":"DaysTicker"},{"attributes":{"bottom":{"expr":{"id":"7233"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"7234"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7269","type":"VBar"},{"attributes":{"days":[1,8,15,22]},"id":"7256","type":"DaysTicker"},{"attributes":{"months":[0,6]},"id":"7261","type":"MonthsTicker"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Contributors","@$name"],["Date","@month{%b %Y}"]]},"id":"7209","type":"HoverTool"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"7259","type":"MonthsTicker"},{"attributes":{"tools":[{"id":"7209"}]},"id":"7229","type":"Toolbar"},{"attributes":{"below":[{"id":"7221"}],"center":[{"id":"7224"},{"id":"7228"},{"id":"7263"}],"height":200,"left":[{"id":"7225"}],"renderers":[{"id":"7240"},{"id":"7270"}],"sizing_mode":"scale_width","title":{"id":"7211"},"toolbar":{"id":"7229"},"width":800,"x_range":{"id":"7213"},"x_scale":{"id":"7217"},"y_range":{"id":"7215"},"y_scale":{"id":"7219"}},"id":"7210","subtype":"Figure","type":"Plot"},{"attributes":{"months":[0,4,8]},"id":"7260","type":"MonthsTicker"},{"attributes":{},"id":"7217","type":"LinearScale"},{"attributes":{},"id":"7219","type":"LinearScale"},{"attributes":{"fields":["External"]},"id":"7232","type":"Stack"}],"root_ids":["7210"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('7571').textContent;
                   const render_items = [{"docid":"217b88de-61d1-4c6e-8abf-f1629cf84a59","root_ids":["7210"],"roots":{"7210":"5891240a-a6b9-44e5-858a-bc0017df8935"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/xcollection-downloads.html
+++ b/images/metrics/xcollection-downloads.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="8c7aab68-9807-46e4-86c0-d67f5408b0e6" data-root-id="2100"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="2461">
           {"a2ae8b8e-0fc6-48a3-9d5d-60951d89fce5":{"defs":[],"roots":{"references":[{"attributes":{"coordinates":null,"group":null,"text":"Package Downloads","text_font_size":"1rem"},"id":"2101","type":"Title"},{"attributes":{"data":{"Conda":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,236,0,0],"PyPI":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,317,1758,715,719],"month":[1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"2172"},"selection_policy":{"id":"2171"}},"id":"2155","type":"ColumnDataSource"},{"attributes":{"bottom":{"expr":{"id":"2123"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"2124"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2158","type":"VBar"},{"attributes":{},"id":"2138","type":"AllLabels"},{"attributes":{"source":{"id":"2125"}},"id":"2131","type":"CDSView"},{"attributes":{"coordinates":null,"formatter":{"id":"2098"},"group":null,"major_label_policy":{"id":"2135"},"ticker":{"id":"2116"}},"id":"2115","type":"LinearAxis"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Downloads","@$name"],["Date","@month{%b %Y}"]]},"id":"2099","type":"HoverTool"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"2141","type":"AdaptiveTicker"},{"attributes":{"bottom":{"expr":{"id":"2123"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"2124"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2159","type":"VBar"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"2141"},{"id":"2142"},{"id":"2143"},{"id":"2144"},{"id":"2145"},{"id":"2146"},{"id":"2147"},{"id":"2148"},{"id":"2149"},{"id":"2150"},{"id":"2151"},{"id":"2152"}]},"id":"2112","type":"DatetimeTicker"},{"attributes":{},"id":"2135","type":"AllLabels"},{"attributes":{"axis":{"id":"2111"},"coordinates":null,"group":null,"ticker":null},"id":"2114","type":"Grid"},{"attributes":{},"id":"2172","type":"Selection"},{"attributes":{},"id":"2152","type":"YearsTicker"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"2143","type":"AdaptiveTicker"},{"attributes":{"fields":["PyPI"]},"id":"2122","type":"Stack"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"2144","type":"DaysTicker"},{"attributes":{},"id":"2116","type":"BasicTicker"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"2142","type":"AdaptiveTicker"},{"attributes":{},"id":"2139","type":"UnionRenderers"},{"attributes":{"coordinates":null,"formatter":{"id":"2097"},"group":null,"major_label_policy":{"id":"2138"},"ticker":{"id":"2112"}},"id":"2111","type":"DatetimeAxis"},{"attributes":{},"id":"2107","type":"LinearScale"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"2145","type":"DaysTicker"},{"attributes":{},"id":"2140","type":"Selection"},{"attributes":{"days":[1,15]},"id":"2147","type":"DaysTicker"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"2148","type":"MonthsTicker"},{"attributes":{"axis":{"id":"2115"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"2118","type":"Grid"},{"attributes":{"data":{"Conda":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,236,0,0],"PyPI":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,317,1758,715,719],"month":[1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"2140"},"selection_policy":{"id":"2139"}},"id":"2125","type":"ColumnDataSource"},{"attributes":{"below":[{"id":"2111"}],"center":[{"id":"2114"},{"id":"2118"},{"id":"2153"}],"height":200,"left":[{"id":"2115"}],"renderers":[{"id":"2130"},{"id":"2160"}],"sizing_mode":"scale_width","title":{"id":"2101"},"toolbar":{"id":"2119"},"width":800,"x_range":{"id":"2103"},"x_scale":{"id":"2107"},"y_range":{"id":"2105"},"y_scale":{"id":"2109"}},"id":"2100","subtype":"Figure","type":"Plot"},{"attributes":{"source":{"id":"2155"}},"id":"2161","type":"CDSView"},{"attributes":{"tools":[{"id":"2099"}]},"id":"2119","type":"Toolbar"},{"attributes":{"bottom":{"expr":{"id":"2121"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"2122"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2129","type":"VBar"},{"attributes":{"bottom":{"expr":{"id":"2121"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"2122"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2127","type":"VBar"},{"attributes":{"coordinates":null,"data_source":{"id":"2155"},"glyph":{"id":"2157"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"2159"},"name":"Conda","nonselection_glyph":{"id":"2158"},"view":{"id":"2161"}},"id":"2160","type":"GlyphRenderer"},{"attributes":{},"id":"2109","type":"LinearScale"},{"attributes":{"fields":["PyPI"]},"id":"2123","type":"Stack"},{"attributes":{"label":{"value":"PyPI"},"renderers":[{"id":"2130"}]},"id":"2154","type":"LegendItem"},{"attributes":{"coordinates":null,"data_source":{"id":"2125"},"glyph":{"id":"2127"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"2129"},"name":"PyPI","nonselection_glyph":{"id":"2128"},"view":{"id":"2131"}},"id":"2130","type":"GlyphRenderer"},{"attributes":{"format":"%6.1u"},"id":"2098","type":"PrintfTickFormatter"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"2149","type":"MonthsTicker"},{"attributes":{"bottom":{"expr":{"id":"2123"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"2124"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2157","type":"VBar"},{"attributes":{"end":2193.4},"id":"2105","type":"Range1d"},{"attributes":{"fields":["PyPI","Conda"]},"id":"2124","type":"Stack"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"2097","type":"DatetimeTickFormatter"},{"attributes":{"fields":[]},"id":"2121","type":"Stack"},{"attributes":{"months":[0,4,8]},"id":"2150","type":"MonthsTicker"},{"attributes":{"end":1645142400000.0,"start":1547510400000.0},"id":"2103","type":"Range1d"},{"attributes":{"bottom":{"expr":{"id":"2121"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"2122"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2128","type":"VBar"},{"attributes":{"days":[1,8,15,22]},"id":"2146","type":"DaysTicker"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"2154"},{"id":"2185"}],"location":"top_left"},"id":"2153","type":"Legend"},{"attributes":{"months":[0,6]},"id":"2151","type":"MonthsTicker"},{"attributes":{},"id":"2171","type":"UnionRenderers"},{"attributes":{"label":{"value":"Conda"},"renderers":[{"id":"2160"}]},"id":"2185","type":"LegendItem"}],"root_ids":["2100"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('2461').textContent;
                   const render_items = [{"docid":"a2ae8b8e-0fc6-48a3-9d5d-60951d89fce5","root_ids":["2100"],"roots":{"2100":"8c7aab68-9807-46e4-86c0-d67f5408b0e6"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/xpersist-burndown.html
+++ b/images/metrics/xpersist-burndown.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="ad6b2ab9-4061-4058-b977-1035ecda0dc0" data-root-id="10003"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="10282">
           {"8fe15d99-78c6-4f51-9be2-8f33f34ce6e0":{"defs":[],"roots":{"references":[{"attributes":{"end":9.9},"id":"10008","type":"Range1d"},{"attributes":{"coordinates":null,"formatter":{"id":"10001"},"group":null,"major_label_policy":{"id":"10037"},"ticker":{"id":"10019"}},"id":"10018","type":"LinearAxis"},{"attributes":{"data":{"month":[1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0],"nopen":[0,0,0,0,0,0,0,0,0,0,3,3,3,4,4,4,5,5,5,5,7,7,7,6,6,6,6,6,6,6,6,6,6,6,6,9,9]},"selected":{"id":"10041"},"selection_policy":{"id":"10040"}},"id":"10026","type":"ColumnDataSource"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"10042","type":"AdaptiveTicker"},{"attributes":{},"id":"10040","type":"UnionRenderers"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"10000","type":"DatetimeTickFormatter"},{"attributes":{"fields":["nopen"]},"id":"10025","type":"Stack"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"10043","type":"AdaptiveTicker"},{"attributes":{"axis":{"id":"10018"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"10021","type":"Grid"},{"attributes":{},"id":"10012","type":"LinearScale"},{"attributes":{"source":{"id":"10026"}},"id":"10032","type":"CDSView"},{"attributes":{},"id":"10039","type":"AllLabels"},{"attributes":{"coordinates":null,"group":null,"text":"Open Issues","text_font_size":"1rem"},"id":"10004","type":"Title"},{"attributes":{"bottom":{"expr":{"id":"10024"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"10025"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"10029","type":"VBar"},{"attributes":{},"id":"10019","type":"BasicTicker"},{"attributes":{"format":"%6.1u"},"id":"10001","type":"PrintfTickFormatter"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"10044","type":"AdaptiveTicker"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"10046","type":"DaysTicker"},{"attributes":{"months":[0,6]},"id":"10052","type":"MonthsTicker"},{"attributes":{"bottom":{"expr":{"id":"10024"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"10025"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"10028","type":"VBar"},{"attributes":{"days":[1,15]},"id":"10048","type":"DaysTicker"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"10045","type":"DaysTicker"},{"attributes":{"tools":[{"id":"10002"}]},"id":"10022","type":"Toolbar"},{"attributes":{"bottom":{"expr":{"id":"10024"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"10025"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"10030","type":"VBar"},{"attributes":{},"id":"10037","type":"AllLabels"},{"attributes":{"months":[0,4,8]},"id":"10051","type":"MonthsTicker"},{"attributes":{},"id":"10041","type":"Selection"},{"attributes":{"fields":[]},"id":"10024","type":"Stack"},{"attributes":{"end":1642464000000.0,"start":1544832000000.0},"id":"10006","type":"Range1d"},{"attributes":{"coordinates":null,"data_source":{"id":"10026"},"glyph":{"id":"10028"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"10030"},"name":"nopen","nonselection_glyph":{"id":"10029"},"view":{"id":"10032"}},"id":"10031","type":"GlyphRenderer"},{"attributes":{},"id":"10010","type":"LinearScale"},{"attributes":{"coordinates":null,"formatter":{"id":"10000"},"group":null,"major_label_policy":{"id":"10039"},"ticker":{"id":"10015"}},"id":"10014","type":"DatetimeAxis"},{"attributes":{"days":[1,8,15,22]},"id":"10047","type":"DaysTicker"},{"attributes":{},"id":"10053","type":"YearsTicker"},{"attributes":{"axis":{"id":"10014"},"coordinates":null,"group":null,"ticker":null},"id":"10017","type":"Grid"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"10050","type":"MonthsTicker"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"10049","type":"MonthsTicker"},{"attributes":{"below":[{"id":"10014"}],"center":[{"id":"10017"},{"id":"10021"}],"height":200,"left":[{"id":"10018"}],"renderers":[{"id":"10031"}],"sizing_mode":"scale_width","title":{"id":"10004"},"toolbar":{"id":"10022"},"width":800,"x_range":{"id":"10006"},"x_scale":{"id":"10010"},"y_range":{"id":"10008"},"y_scale":{"id":"10012"}},"id":"10003","subtype":"Figure","type":"Plot"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Issues","@$name"],["Date","@month{%b %Y}"]]},"id":"10002","type":"HoverTool"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"10042"},{"id":"10043"},{"id":"10044"},{"id":"10045"},{"id":"10046"},{"id":"10047"},{"id":"10048"},{"id":"10049"},{"id":"10050"},{"id":"10051"},{"id":"10052"},{"id":"10053"}]},"id":"10015","type":"DatetimeTicker"}],"root_ids":["10003"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('10282').textContent;
                   const render_items = [{"docid":"8fe15d99-78c6-4f51-9be2-8f33f34ce6e0","root_ids":["10003"],"roots":{"10003":"ad6b2ab9-4061-4058-b977-1035ecda0dc0"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/xpersist-commits.html
+++ b/images/metrics/xpersist-commits.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="6c900f27-1167-4df0-a1ed-fc245605b310" data-root-id="3925"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="4286">
           {"32b00131-88bb-4b40-99fc-e6c05b225cde":{"defs":[],"roots":{"references":[{"attributes":{"coordinates":null,"data_source":{"id":"3950"},"glyph":{"id":"3952"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"3954"},"name":"External","nonselection_glyph":{"id":"3953"},"view":{"id":"3956"}},"id":"3955","type":"GlyphRenderer"},{"attributes":{"format":"%6.1u"},"id":"3923","type":"PrintfTickFormatter"},{"attributes":{"fields":["External","Internal"]},"id":"3949","type":"Stack"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"3966"},{"id":"3967"},{"id":"3968"},{"id":"3969"},{"id":"3970"},{"id":"3971"},{"id":"3972"},{"id":"3973"},{"id":"3974"},{"id":"3975"},{"id":"3976"},{"id":"3977"}]},"id":"3937","type":"DatetimeTicker"},{"attributes":{},"id":"3934","type":"LinearScale"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"3979"},{"id":"4010"}],"location":"top_left"},"id":"3978","type":"Legend"},{"attributes":{"coordinates":null,"formatter":{"id":"3922"},"group":null,"major_label_policy":{"id":"3963"},"ticker":{"id":"3937"}},"id":"3936","type":"DatetimeAxis"},{"attributes":{"days":[1,15]},"id":"3972","type":"DaysTicker"},{"attributes":{"end":3617.9},"id":"3930","type":"Range1d"},{"attributes":{"days":[1,8,15,22]},"id":"3971","type":"DaysTicker"},{"attributes":{"bottom":{"expr":{"id":"3946"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"3947"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3954","type":"VBar"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,54,0,0],"Internal":[0,0,0,0,0,0,0,0,0,0,0,1270,0,0,0,0,0,0,0,0,0,0,0,0,613,31,0,0,0,0,0,0,0,0,0,0,3235,271,0],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"3997"},"selection_policy":{"id":"3996"}},"id":"3980","type":"ColumnDataSource"},{"attributes":{},"id":"3996","type":"UnionRenderers"},{"attributes":{},"id":"3997","type":"Selection"},{"attributes":{"bottom":{"expr":{"id":"3948"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"3949"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3982","type":"VBar"},{"attributes":{"label":{"value":"External"},"renderers":[{"id":"3955"}]},"id":"3979","type":"LegendItem"},{"attributes":{"months":[0,6]},"id":"3976","type":"MonthsTicker"},{"attributes":{},"id":"3932","type":"LinearScale"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"3969","type":"DaysTicker"},{"attributes":{"tools":[{"id":"3924"}]},"id":"3944","type":"Toolbar"},{"attributes":{"source":{"id":"3950"}},"id":"3956","type":"CDSView"},{"attributes":{"bottom":{"expr":{"id":"3948"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"3949"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3984","type":"VBar"},{"attributes":{},"id":"3965","type":"Selection"},{"attributes":{"axis":{"id":"3936"},"coordinates":null,"group":null,"ticker":null},"id":"3939","type":"Grid"},{"attributes":{"fields":["External"]},"id":"3947","type":"Stack"},{"attributes":{"bottom":{"expr":{"id":"3946"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"3947"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3953","type":"VBar"},{"attributes":{},"id":"3941","type":"BasicTicker"},{"attributes":{"end":1645142400000.0,"start":1542153600000.0},"id":"3928","type":"Range1d"},{"attributes":{"bottom":{"expr":{"id":"3948"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"3949"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3983","type":"VBar"},{"attributes":{},"id":"3960","type":"AllLabels"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"3966","type":"AdaptiveTicker"},{"attributes":{},"id":"3977","type":"YearsTicker"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Commits","@$name"],["Date","@month{%b %Y}"]]},"id":"3924","type":"HoverTool"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"3974","type":"MonthsTicker"},{"attributes":{"bottom":{"expr":{"id":"3946"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"3947"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"3952","type":"VBar"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"3970","type":"DaysTicker"},{"attributes":{"axis":{"id":"3940"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"3943","type":"Grid"},{"attributes":{"coordinates":null,"formatter":{"id":"3923"},"group":null,"major_label_policy":{"id":"3960"},"ticker":{"id":"3941"}},"id":"3940","type":"LinearAxis"},{"attributes":{"fields":[]},"id":"3946","type":"Stack"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,54,0,0],"Internal":[0,0,0,0,0,0,0,0,0,0,0,1270,0,0,0,0,0,0,0,0,0,0,0,0,613,31,0,0,0,0,0,0,0,0,0,0,3235,271,0],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"3965"},"selection_policy":{"id":"3964"}},"id":"3950","type":"ColumnDataSource"},{"attributes":{"below":[{"id":"3936"}],"center":[{"id":"3939"},{"id":"3943"},{"id":"3978"}],"height":200,"left":[{"id":"3940"}],"renderers":[{"id":"3955"},{"id":"3985"}],"sizing_mode":"scale_width","title":{"id":"3926"},"toolbar":{"id":"3944"},"width":800,"x_range":{"id":"3928"},"x_scale":{"id":"3932"},"y_range":{"id":"3930"},"y_scale":{"id":"3934"}},"id":"3925","subtype":"Figure","type":"Plot"},{"attributes":{},"id":"3964","type":"UnionRenderers"},{"attributes":{},"id":"3963","type":"AllLabels"},{"attributes":{"fields":["External"]},"id":"3948","type":"Stack"},{"attributes":{"coordinates":null,"group":null,"text":"Repository Commits","text_font_size":"1rem"},"id":"3926","type":"Title"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"3973","type":"MonthsTicker"},{"attributes":{"label":{"value":"Internal"},"renderers":[{"id":"3985"}]},"id":"4010","type":"LegendItem"},{"attributes":{"months":[0,4,8]},"id":"3975","type":"MonthsTicker"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"3968","type":"AdaptiveTicker"},{"attributes":{"source":{"id":"3980"}},"id":"3986","type":"CDSView"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"3967","type":"AdaptiveTicker"},{"attributes":{"coordinates":null,"data_source":{"id":"3980"},"glyph":{"id":"3982"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"3984"},"name":"Internal","nonselection_glyph":{"id":"3983"},"view":{"id":"3986"}},"id":"3985","type":"GlyphRenderer"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"3922","type":"DatetimeTickFormatter"}],"root_ids":["3925"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('4286').textContent;
                   const render_items = [{"docid":"32b00131-88bb-4b40-99fc-e6c05b225cde","root_ids":["3925"],"roots":{"3925":"6c900f27-1167-4df0-a1ed-fc245605b310"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/xpersist-contributors.html
+++ b/images/metrics/xpersist-contributors.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="25ba8262-6380-4f45-af2b-2b021d36cf93" data-root-id="7575"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="7936">
           {"2bd26b3d-9b9f-4a7a-9952-098e704e6d53":{"defs":[],"roots":{"references":[{"attributes":{"format":"%6.1u"},"id":"7573","type":"PrintfTickFormatter"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"7616"},{"id":"7617"},{"id":"7618"},{"id":"7619"},{"id":"7620"},{"id":"7621"},{"id":"7622"},{"id":"7623"},{"id":"7624"},{"id":"7625"},{"id":"7626"},{"id":"7627"}]},"id":"7587","type":"DatetimeTicker"},{"attributes":{},"id":"7610","type":"AllLabels"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"7616","type":"AdaptiveTicker"},{"attributes":{},"id":"7613","type":"AllLabels"},{"attributes":{"bottom":{"expr":{"id":"7598"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"7599"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7632","type":"VBar"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"7629"},{"id":"7660"}],"location":"top_left"},"id":"7628","type":"Legend"},{"attributes":{},"id":"7591","type":"BasicTicker"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"7617","type":"AdaptiveTicker"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"7618","type":"AdaptiveTicker"},{"attributes":{},"id":"7627","type":"YearsTicker"},{"attributes":{"axis":{"id":"7590"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"7593","type":"Grid"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"7623","type":"MonthsTicker"},{"attributes":{"days":[1,15]},"id":"7622","type":"DaysTicker"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1],"Internal":[0,0,0,0,0,0,0,0,0,0,0,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"7615"},"selection_policy":{"id":"7614"}},"id":"7600","type":"ColumnDataSource"},{"attributes":{"bottom":{"expr":{"id":"7596"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"7597"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7602","type":"VBar"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"7619","type":"DaysTicker"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Contributors","@$name"],["Date","@month{%b %Y}"]]},"id":"7574","type":"HoverTool"},{"attributes":{"coordinates":null,"formatter":{"id":"7572"},"group":null,"major_label_policy":{"id":"7613"},"ticker":{"id":"7587"}},"id":"7586","type":"DatetimeAxis"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"7620","type":"DaysTicker"},{"attributes":{"source":{"id":"7630"}},"id":"7636","type":"CDSView"},{"attributes":{"days":[1,8,15,22]},"id":"7621","type":"DaysTicker"},{"attributes":{},"id":"7582","type":"LinearScale"},{"attributes":{"end":3.3000000000000003},"id":"7580","type":"Range1d"},{"attributes":{"months":[0,6]},"id":"7626","type":"MonthsTicker"},{"attributes":{"coordinates":null,"data_source":{"id":"7600"},"glyph":{"id":"7602"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"7604"},"name":"External","nonselection_glyph":{"id":"7603"},"view":{"id":"7606"}},"id":"7605","type":"GlyphRenderer"},{"attributes":{"bottom":{"expr":{"id":"7596"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"7597"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7604","type":"VBar"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"7624","type":"MonthsTicker"},{"attributes":{"coordinates":null,"group":null,"text":"Number of Contributors","text_font_size":"1rem"},"id":"7576","type":"Title"},{"attributes":{},"id":"7614","type":"UnionRenderers"},{"attributes":{"bottom":{"expr":{"id":"7598"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"7599"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7633","type":"VBar"},{"attributes":{"tools":[{"id":"7574"}]},"id":"7594","type":"Toolbar"},{"attributes":{"months":[0,4,8]},"id":"7625","type":"MonthsTicker"},{"attributes":{},"id":"7615","type":"Selection"},{"attributes":{"fields":["External"]},"id":"7597","type":"Stack"},{"attributes":{},"id":"7647","type":"Selection"},{"attributes":{"coordinates":null,"formatter":{"id":"7573"},"group":null,"major_label_policy":{"id":"7610"},"ticker":{"id":"7591"}},"id":"7590","type":"LinearAxis"},{"attributes":{"axis":{"id":"7586"},"coordinates":null,"group":null,"ticker":null},"id":"7589","type":"Grid"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"7572","type":"DatetimeTickFormatter"},{"attributes":{"source":{"id":"7600"}},"id":"7606","type":"CDSView"},{"attributes":{"label":{"value":"Internal"},"renderers":[{"id":"7635"}]},"id":"7660","type":"LegendItem"},{"attributes":{"fields":[]},"id":"7596","type":"Stack"},{"attributes":{},"id":"7584","type":"LinearScale"},{"attributes":{"fields":["External"]},"id":"7598","type":"Stack"},{"attributes":{"end":1645142400000.0,"start":1542153600000.0},"id":"7578","type":"Range1d"},{"attributes":{"bottom":{"expr":{"id":"7598"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"7599"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7634","type":"VBar"},{"attributes":{"label":{"value":"External"},"renderers":[{"id":"7605"}]},"id":"7629","type":"LegendItem"},{"attributes":{"fields":["External","Internal"]},"id":"7599","type":"Stack"},{"attributes":{"below":[{"id":"7586"}],"center":[{"id":"7589"},{"id":"7593"},{"id":"7628"}],"height":200,"left":[{"id":"7590"}],"renderers":[{"id":"7605"},{"id":"7635"}],"sizing_mode":"scale_width","title":{"id":"7576"},"toolbar":{"id":"7594"},"width":800,"x_range":{"id":"7578"},"x_scale":{"id":"7582"},"y_range":{"id":"7580"},"y_scale":{"id":"7584"}},"id":"7575","subtype":"Figure","type":"Plot"},{"attributes":{"coordinates":null,"data_source":{"id":"7630"},"glyph":{"id":"7632"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"7634"},"name":"Internal","nonselection_glyph":{"id":"7633"},"view":{"id":"7636"}},"id":"7635","type":"GlyphRenderer"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1],"Internal":[0,0,0,0,0,0,0,0,0,0,0,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"7647"},"selection_policy":{"id":"7646"}},"id":"7630","type":"ColumnDataSource"},{"attributes":{},"id":"7646","type":"UnionRenderers"},{"attributes":{"bottom":{"expr":{"id":"7596"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"7597"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7603","type":"VBar"}],"root_ids":["7575"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('7936').textContent;
                   const render_items = [{"docid":"2bd26b3d-9b9f-4a7a-9952-098e704e6d53","root_ids":["7575"],"roots":{"7575":"25ba8262-6380-4f45-af2b-2b021d36cf93"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/xpersist-downloads.html
+++ b/images/metrics/xpersist-downloads.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="2776b2ce-ac36-4a82-85d9-3a85f982e6b0" data-root-id="2465"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="2826">
           {"ca207737-40e1-4be2-86ee-509e24de2779":{"defs":[],"roots":{"references":[{"attributes":{"bottom":{"expr":{"id":"2488"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"2489"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2524","type":"VBar"},{"attributes":{"bottom":{"expr":{"id":"2488"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"2489"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2522","type":"VBar"},{"attributes":{"months":[0,4,8]},"id":"2515","type":"MonthsTicker"},{"attributes":{"tools":[{"id":"2464"}]},"id":"2484","type":"Toolbar"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"2506"},{"id":"2507"},{"id":"2508"},{"id":"2509"},{"id":"2510"},{"id":"2511"},{"id":"2512"},{"id":"2513"},{"id":"2514"},{"id":"2515"},{"id":"2516"},{"id":"2517"}]},"id":"2477","type":"DatetimeTicker"},{"attributes":{"bottom":{"expr":{"id":"2486"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"2487"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2493","type":"VBar"},{"attributes":{"end":700.7},"id":"2470","type":"Range1d"},{"attributes":{"label":{"value":"Conda"},"renderers":[{"id":"2525"}]},"id":"2550","type":"LegendItem"},{"attributes":{"bottom":{"expr":{"id":"2486"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"2487"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2494","type":"VBar"},{"attributes":{},"id":"2474","type":"LinearScale"},{"attributes":{"coordinates":null,"data_source":{"id":"2490"},"glyph":{"id":"2492"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"2494"},"name":"PyPI","nonselection_glyph":{"id":"2493"},"view":{"id":"2496"}},"id":"2495","type":"GlyphRenderer"},{"attributes":{"fields":["PyPI","Conda"]},"id":"2489","type":"Stack"},{"attributes":{"bottom":{"expr":{"id":"2486"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"2487"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2492","type":"VBar"},{"attributes":{"fields":[]},"id":"2486","type":"Stack"},{"attributes":{"data":{"Conda":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,50,0,0],"PyPI":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,587,286,120],"month":[1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"2505"},"selection_policy":{"id":"2504"}},"id":"2490","type":"ColumnDataSource"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Downloads","@$name"],["Date","@month{%b %Y}"]]},"id":"2464","type":"HoverTool"},{"attributes":{"coordinates":null,"formatter":{"id":"2463"},"group":null,"major_label_policy":{"id":"2500"},"ticker":{"id":"2481"}},"id":"2480","type":"LinearAxis"},{"attributes":{"axis":{"id":"2480"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"2483","type":"Grid"},{"attributes":{"source":{"id":"2520"}},"id":"2526","type":"CDSView"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"2514","type":"MonthsTicker"},{"attributes":{"days":[1,15]},"id":"2512","type":"DaysTicker"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"2462","type":"DatetimeTickFormatter"},{"attributes":{},"id":"2500","type":"AllLabels"},{"attributes":{"source":{"id":"2490"}},"id":"2496","type":"CDSView"},{"attributes":{"label":{"value":"PyPI"},"renderers":[{"id":"2495"}]},"id":"2519","type":"LegendItem"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"2513","type":"MonthsTicker"},{"attributes":{},"id":"2517","type":"YearsTicker"},{"attributes":{"data":{"Conda":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,50,0,0],"PyPI":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,587,286,120],"month":[1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"2537"},"selection_policy":{"id":"2536"}},"id":"2520","type":"ColumnDataSource"},{"attributes":{},"id":"2504","type":"UnionRenderers"},{"attributes":{},"id":"2537","type":"Selection"},{"attributes":{"fields":["PyPI"]},"id":"2487","type":"Stack"},{"attributes":{"coordinates":null,"data_source":{"id":"2520"},"glyph":{"id":"2522"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"2524"},"name":"Conda","nonselection_glyph":{"id":"2523"},"view":{"id":"2526"}},"id":"2525","type":"GlyphRenderer"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"2506","type":"AdaptiveTicker"},{"attributes":{},"id":"2503","type":"AllLabels"},{"attributes":{"end":1645142400000.0,"start":1547510400000.0},"id":"2468","type":"Range1d"},{"attributes":{},"id":"2472","type":"LinearScale"},{"attributes":{"axis":{"id":"2476"},"coordinates":null,"group":null,"ticker":null},"id":"2479","type":"Grid"},{"attributes":{"fields":["PyPI"]},"id":"2488","type":"Stack"},{"attributes":{},"id":"2536","type":"UnionRenderers"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"2507","type":"AdaptiveTicker"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"2509","type":"DaysTicker"},{"attributes":{"below":[{"id":"2476"}],"center":[{"id":"2479"},{"id":"2483"},{"id":"2518"}],"height":200,"left":[{"id":"2480"}],"renderers":[{"id":"2495"},{"id":"2525"}],"sizing_mode":"scale_width","title":{"id":"2466"},"toolbar":{"id":"2484"},"width":800,"x_range":{"id":"2468"},"x_scale":{"id":"2472"},"y_range":{"id":"2470"},"y_scale":{"id":"2474"}},"id":"2465","subtype":"Figure","type":"Plot"},{"attributes":{"coordinates":null,"formatter":{"id":"2462"},"group":null,"major_label_policy":{"id":"2503"},"ticker":{"id":"2477"}},"id":"2476","type":"DatetimeAxis"},{"attributes":{"bottom":{"expr":{"id":"2488"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"2489"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"2523","type":"VBar"},{"attributes":{"coordinates":null,"group":null,"text":"Package Downloads","text_font_size":"1rem"},"id":"2466","type":"Title"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"2508","type":"AdaptiveTicker"},{"attributes":{"days":[1,8,15,22]},"id":"2511","type":"DaysTicker"},{"attributes":{"months":[0,6]},"id":"2516","type":"MonthsTicker"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"2519"},{"id":"2550"}],"location":"top_left"},"id":"2518","type":"Legend"},{"attributes":{},"id":"2481","type":"BasicTicker"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"2510","type":"DaysTicker"},{"attributes":{"format":"%6.1u"},"id":"2463","type":"PrintfTickFormatter"},{"attributes":{},"id":"2505","type":"Selection"}],"root_ids":["2465"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('2826').textContent;
                   const render_items = [{"docid":"ca207737-40e1-4be2-86ee-509e24de2779","root_ids":["2465"],"roots":{"2465":"2776b2ce-ac36-4a82-85d9-3a85f982e6b0"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/xwrf-burndown.html
+++ b/images/metrics/xwrf-burndown.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="930abcde-5f94-418a-a8bd-534006f363f6" data-root-id="9437"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="9716">
           {"773a6b9f-c5a2-4dc5-8001-bcb2bb0493c7":{"defs":[],"roots":{"references":[{"attributes":{"coordinates":null,"group":null,"text":"Open Issues","text_font_size":"1rem"},"id":"9438","type":"Title"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"9477","type":"AdaptiveTicker"},{"attributes":{"days":[1,15]},"id":"9482","type":"DaysTicker"},{"attributes":{"data":{"month":[1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0],"nopen":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3,6,6,9]},"selected":{"id":"9475"},"selection_policy":{"id":"9474"}},"id":"9460","type":"ColumnDataSource"},{"attributes":{"bottom":{"expr":{"id":"9458"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"9459"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"9464","type":"VBar"},{"attributes":{"bottom":{"expr":{"id":"9458"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"9459"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"9462","type":"VBar"},{"attributes":{},"id":"9444","type":"LinearScale"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"9479","type":"DaysTicker"},{"attributes":{},"id":"9446","type":"LinearScale"},{"attributes":{"fields":["nopen"]},"id":"9459","type":"Stack"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"9434","type":"DatetimeTickFormatter"},{"attributes":{"bottom":{"expr":{"id":"9458"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"9459"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"9463","type":"VBar"},{"attributes":{"coordinates":null,"formatter":{"id":"9434"},"group":null,"major_label_policy":{"id":"9473"},"ticker":{"id":"9449"}},"id":"9448","type":"DatetimeAxis"},{"attributes":{"fields":[]},"id":"9458","type":"Stack"},{"attributes":{"below":[{"id":"9448"}],"center":[{"id":"9451"},{"id":"9455"}],"height":200,"left":[{"id":"9452"}],"renderers":[{"id":"9465"}],"sizing_mode":"scale_width","title":{"id":"9438"},"toolbar":{"id":"9456"},"width":800,"x_range":{"id":"9440"},"x_scale":{"id":"9444"},"y_range":{"id":"9442"},"y_scale":{"id":"9446"}},"id":"9437","subtype":"Figure","type":"Plot"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"9480","type":"DaysTicker"},{"attributes":{"days":[1,8,15,22]},"id":"9481","type":"DaysTicker"},{"attributes":{},"id":"9471","type":"AllLabels"},{"attributes":{},"id":"9475","type":"Selection"},{"attributes":{"axis":{"id":"9452"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"9455","type":"Grid"},{"attributes":{"months":[0,4,8]},"id":"9485","type":"MonthsTicker"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"9476"},{"id":"9477"},{"id":"9478"},{"id":"9479"},{"id":"9480"},{"id":"9481"},{"id":"9482"},{"id":"9483"},{"id":"9484"},{"id":"9485"},{"id":"9486"},{"id":"9487"}]},"id":"9449","type":"DatetimeTicker"},{"attributes":{},"id":"9474","type":"UnionRenderers"},{"attributes":{"axis":{"id":"9448"},"coordinates":null,"group":null,"ticker":null},"id":"9451","type":"Grid"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"9476","type":"AdaptiveTicker"},{"attributes":{"end":1642464000000.0,"start":1544832000000.0},"id":"9440","type":"Range1d"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"9484","type":"MonthsTicker"},{"attributes":{"tools":[{"id":"9436"}]},"id":"9456","type":"Toolbar"},{"attributes":{},"id":"9487","type":"YearsTicker"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Issues","@$name"],["Date","@month{%b %Y}"]]},"id":"9436","type":"HoverTool"},{"attributes":{},"id":"9453","type":"BasicTicker"},{"attributes":{"format":"%6.1u"},"id":"9435","type":"PrintfTickFormatter"},{"attributes":{"coordinates":null,"data_source":{"id":"9460"},"glyph":{"id":"9462"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"9464"},"name":"nopen","nonselection_glyph":{"id":"9463"},"view":{"id":"9466"}},"id":"9465","type":"GlyphRenderer"},{"attributes":{"end":9.9},"id":"9442","type":"Range1d"},{"attributes":{"coordinates":null,"formatter":{"id":"9435"},"group":null,"major_label_policy":{"id":"9471"},"ticker":{"id":"9453"}},"id":"9452","type":"LinearAxis"},{"attributes":{"source":{"id":"9460"}},"id":"9466","type":"CDSView"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"9478","type":"AdaptiveTicker"},{"attributes":{},"id":"9473","type":"AllLabels"},{"attributes":{"months":[0,6]},"id":"9486","type":"MonthsTicker"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"9483","type":"MonthsTicker"}],"root_ids":["9437"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('9716').textContent;
                   const render_items = [{"docid":"773a6b9f-c5a2-4dc5-8001-bcb2bb0493c7","root_ids":["9437"],"roots":{"9437":"930abcde-5f94-418a-a8bd-534006f363f6"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/xwrf-commits.html
+++ b/images/metrics/xwrf-commits.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="61c8cf98-20ea-4bf9-a642-e7cbd4099d31" data-root-id="5385"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="5746">
           {"57844ba1-0b6c-4cbe-96fc-c4c4dcc7904e":{"defs":[],"roots":{"references":[{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"5426","type":"AdaptiveTicker"},{"attributes":{},"id":"5401","type":"BasicTicker"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"5427","type":"AdaptiveTicker"},{"attributes":{"end":1623.6000000000001},"id":"5390","type":"Range1d"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"5428","type":"AdaptiveTicker"},{"attributes":{"tools":[{"id":"5384"}]},"id":"5404","type":"Toolbar"},{"attributes":{"source":{"id":"5440"}},"id":"5446","type":"CDSView"},{"attributes":{},"id":"5437","type":"YearsTicker"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"5433","type":"MonthsTicker"},{"attributes":{"source":{"id":"5410"}},"id":"5416","type":"CDSView"},{"attributes":{"days":[1,15]},"id":"5432","type":"DaysTicker"},{"attributes":{"label":{"value":"Internal"},"renderers":[{"id":"5445"}]},"id":"5470","type":"LegendItem"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,41,592],"Internal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1224,732,102,43,884],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"5425"},"selection_policy":{"id":"5424"}},"id":"5410","type":"ColumnDataSource"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"5429","type":"DaysTicker"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"5430","type":"DaysTicker"},{"attributes":{"coordinates":null,"data_source":{"id":"5410"},"glyph":{"id":"5412"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"5414"},"name":"External","nonselection_glyph":{"id":"5413"},"view":{"id":"5416"}},"id":"5415","type":"GlyphRenderer"},{"attributes":{},"id":"5424","type":"UnionRenderers"},{"attributes":{"days":[1,8,15,22]},"id":"5431","type":"DaysTicker"},{"attributes":{"end":1645142400000.0,"start":1542153600000.0},"id":"5388","type":"Range1d"},{"attributes":{"months":[0,6]},"id":"5436","type":"MonthsTicker"},{"attributes":{},"id":"5457","type":"Selection"},{"attributes":{"label":{"value":"External"},"renderers":[{"id":"5415"}]},"id":"5439","type":"LegendItem"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"5434","type":"MonthsTicker"},{"attributes":{},"id":"5394","type":"LinearScale"},{"attributes":{},"id":"5456","type":"UnionRenderers"},{"attributes":{"months":[0,4,8]},"id":"5435","type":"MonthsTicker"},{"attributes":{"fields":[]},"id":"5406","type":"Stack"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"5426"},{"id":"5427"},{"id":"5428"},{"id":"5429"},{"id":"5430"},{"id":"5431"},{"id":"5432"},{"id":"5433"},{"id":"5434"},{"id":"5435"},{"id":"5436"},{"id":"5437"}]},"id":"5397","type":"DatetimeTicker"},{"attributes":{"below":[{"id":"5396"}],"center":[{"id":"5399"},{"id":"5403"},{"id":"5438"}],"height":200,"left":[{"id":"5400"}],"renderers":[{"id":"5415"},{"id":"5445"}],"sizing_mode":"scale_width","title":{"id":"5386"},"toolbar":{"id":"5404"},"width":800,"x_range":{"id":"5388"},"x_scale":{"id":"5392"},"y_range":{"id":"5390"},"y_scale":{"id":"5394"}},"id":"5385","subtype":"Figure","type":"Plot"},{"attributes":{"coordinates":null,"group":null,"text":"Repository Commits","text_font_size":"1rem"},"id":"5386","type":"Title"},{"attributes":{},"id":"5425","type":"Selection"},{"attributes":{"axis":{"id":"5400"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"5403","type":"Grid"},{"attributes":{"coordinates":null,"formatter":{"id":"5383"},"group":null,"major_label_policy":{"id":"5420"},"ticker":{"id":"5401"}},"id":"5400","type":"LinearAxis"},{"attributes":{"format":"%6.1u"},"id":"5383","type":"PrintfTickFormatter"},{"attributes":{"bottom":{"expr":{"id":"5406"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"5407"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5412","type":"VBar"},{"attributes":{"bottom":{"expr":{"id":"5406"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"5407"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5413","type":"VBar"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"5439"},{"id":"5470"}],"location":"top_left"},"id":"5438","type":"Legend"},{"attributes":{"bottom":{"expr":{"id":"5408"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"5409"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5443","type":"VBar"},{"attributes":{"coordinates":null,"data_source":{"id":"5440"},"glyph":{"id":"5442"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"5444"},"name":"Internal","nonselection_glyph":{"id":"5443"},"view":{"id":"5446"}},"id":"5445","type":"GlyphRenderer"},{"attributes":{},"id":"5420","type":"AllLabels"},{"attributes":{"axis":{"id":"5396"},"coordinates":null,"group":null,"ticker":null},"id":"5399","type":"Grid"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"5382","type":"DatetimeTickFormatter"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,41,592],"Internal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1224,732,102,43,884],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"5457"},"selection_policy":{"id":"5456"}},"id":"5440","type":"ColumnDataSource"},{"attributes":{"fields":["External"]},"id":"5407","type":"Stack"},{"attributes":{"fields":["External"]},"id":"5408","type":"Stack"},{"attributes":{"bottom":{"expr":{"id":"5406"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"5407"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5414","type":"VBar"},{"attributes":{},"id":"5423","type":"AllLabels"},{"attributes":{"bottom":{"expr":{"id":"5408"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"5409"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5442","type":"VBar"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Commits","@$name"],["Date","@month{%b %Y}"]]},"id":"5384","type":"HoverTool"},{"attributes":{"fields":["External","Internal"]},"id":"5409","type":"Stack"},{"attributes":{"coordinates":null,"formatter":{"id":"5382"},"group":null,"major_label_policy":{"id":"5423"},"ticker":{"id":"5397"}},"id":"5396","type":"DatetimeAxis"},{"attributes":{"bottom":{"expr":{"id":"5408"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"5409"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"5444","type":"VBar"},{"attributes":{},"id":"5392","type":"LinearScale"}],"root_ids":["5385"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('5746').textContent;
                   const render_items = [{"docid":"57844ba1-0b6c-4cbe-96fc-c4c4dcc7904e","root_ids":["5385"],"roots":{"5385":"61c8cf98-20ea-4bf9-a642-e7cbd4099d31"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/images/metrics/xwrf-contributors.html
+++ b/images/metrics/xwrf-contributors.html
@@ -4,42 +4,42 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  
+
   <head>
-    
+
       <meta charset="utf-8">
       <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
+
+
+
+
+
+
+
         <script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js"></script>
         <script type="text/javascript">
             Bokeh.set_log_level("info");
         </script>
-        
-      
-      
-    
+
+
+
+
   </head>
-  
-  
+
+
   <body>
-    
-      
-        
-          
-          
-            
+
+
+
+
+
+
               <div class="bk-root" id="0fdf4875-b65b-43b9-87e9-7f2c33fc9eef" data-root-id="7940"></div>
-            
-          
-        
-      
-      
+
+
+
+
+
         <script type="application/json" id="8301">
           {"9fe17bbf-95ed-4d31-8ef9-1932ff846d38":{"defs":[],"roots":{"references":[{"attributes":{"bottom":{"expr":{"id":"7961"}},"fill_color":{"value":"#2171b5"},"hatch_color":{"value":"#2171b5"},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"7962"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7967","type":"VBar"},{"attributes":{"end":5.5},"id":"7945","type":"Range1d"},{"attributes":{"months":[0,4,8]},"id":"7990","type":"MonthsTicker"},{"attributes":{"months":[0,6]},"id":"7991","type":"MonthsTicker"},{"attributes":{"bottom":{"expr":{"id":"7961"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.1},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"7962"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7968","type":"VBar"},{"attributes":{"days":[1,4,7,10,13,16,19,22,25,28]},"id":"7985","type":"DaysTicker"},{"attributes":{"source":{"id":"7995"}},"id":"8001","type":"CDSView"},{"attributes":{"axis":{"id":"7951"},"coordinates":null,"group":null,"ticker":null},"id":"7954","type":"Grid"},{"attributes":{"months":[0,1,2,3,4,5,6,7,8,9,10,11]},"id":"7988","type":"MonthsTicker"},{"attributes":{"fields":[]},"id":"7961","type":"Stack"},{"attributes":{"coordinates":null,"group":null,"text":"Number of Contributors","text_font_size":"1rem"},"id":"7941","type":"Title"},{"attributes":{"coordinates":null,"group":null,"items":[{"id":"7994"},{"id":"8025"}],"location":"top_left"},"id":"7993","type":"Legend"},{"attributes":{},"id":"7992","type":"YearsTicker"},{"attributes":{"days":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},"id":"7984","type":"DaysTicker"},{"attributes":{},"id":"7979","type":"UnionRenderers"},{"attributes":{"months":[0,2,4,6,8,10]},"id":"7989","type":"MonthsTicker"},{"attributes":{"days":[1,15]},"id":"7987","type":"DaysTicker"},{"attributes":{"bottom":{"expr":{"id":"7963"}},"fill_color":{"value":"#6baed6"},"hatch_color":{"value":"#6baed6"},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"7964"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7997","type":"VBar"},{"attributes":{"fields":["External","Internal"]},"id":"7964","type":"Stack"},{"attributes":{"num_minor_ticks":5,"tickers":[{"id":"7981"},{"id":"7982"},{"id":"7983"},{"id":"7984"},{"id":"7985"},{"id":"7986"},{"id":"7987"},{"id":"7988"},{"id":"7989"},{"id":"7990"},{"id":"7991"},{"id":"7992"}]},"id":"7952","type":"DatetimeTicker"},{"attributes":{"axis":{"id":"7955"},"coordinates":null,"dimension":1,"group":null,"ticker":null},"id":"7958","type":"Grid"},{"attributes":{"base":24,"mantissas":[1,2,4,6,8,12],"max_interval":43200000.0,"min_interval":3600000.0,"num_minor_ticks":0},"id":"7983","type":"AdaptiveTicker"},{"attributes":{"bottom":{"expr":{"id":"7963"}},"fill_alpha":{"value":0.1},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.1},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.1},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"7964"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7998","type":"VBar"},{"attributes":{"fields":["External"]},"id":"7963","type":"Stack"},{"attributes":{"base":60,"mantissas":[1,2,5,10,15,20,30],"max_interval":1800000.0,"min_interval":1000.0,"num_minor_ticks":0},"id":"7982","type":"AdaptiveTicker"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,2],"Internal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,2,2,3],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"7980"},"selection_policy":{"id":"7979"}},"id":"7965","type":"ColumnDataSource"},{"attributes":{"coordinates":null,"formatter":{"id":"7937"},"group":null,"major_label_policy":{"id":"7978"},"ticker":{"id":"7952"}},"id":"7951","type":"DatetimeAxis"},{"attributes":{},"id":"8012","type":"Selection"},{"attributes":{"coordinates":null,"data_source":{"id":"7965"},"glyph":{"id":"7967"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"7969"},"name":"External","nonselection_glyph":{"id":"7968"},"view":{"id":"7971"}},"id":"7970","type":"GlyphRenderer"},{"attributes":{},"id":"7947","type":"LinearScale"},{"attributes":{"label":{"value":"Internal"},"renderers":[{"id":"8000"}]},"id":"8025","type":"LegendItem"},{"attributes":{"mantissas":[1,2,5],"max_interval":500.0,"num_minor_ticks":0},"id":"7981","type":"AdaptiveTicker"},{"attributes":{"data":{"External":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,2],"Internal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,2,2,3],"month":[1543622400000.0,1546300800000.0,1548979200000.0,1551398400000.0,1554076800000.0,1556668800000.0,1559347200000.0,1561939200000.0,1564617600000.0,1567296000000.0,1569888000000.0,1572566400000.0,1575158400000.0,1577836800000.0,1580515200000.0,1583020800000.0,1585699200000.0,1588291200000.0,1590969600000.0,1593561600000.0,1596240000000.0,1598918400000.0,1601510400000.0,1604188800000.0,1606780800000.0,1609459200000.0,1612137600000.0,1614556800000.0,1617235200000.0,1619827200000.0,1622505600000.0,1625097600000.0,1627776000000.0,1630454400000.0,1633046400000.0,1635724800000.0,1638316800000.0,1640995200000.0,1643673600000.0]},"selected":{"id":"8012"},"selection_policy":{"id":"8011"}},"id":"7995","type":"ColumnDataSource"},{"attributes":{"days":["%d %b %Y"],"months":["%b %Y"]},"id":"7937","type":"DatetimeTickFormatter"},{"attributes":{"callback":null,"formatters":{"@month":"datetime"},"tooltips":[["Source","$name"],["Contributors","@$name"],["Date","@month{%b %Y}"]]},"id":"7939","type":"HoverTool"},{"attributes":{},"id":"7949","type":"LinearScale"},{"attributes":{},"id":"7980","type":"Selection"},{"attributes":{},"id":"8011","type":"UnionRenderers"},{"attributes":{"format":"%6.1u"},"id":"7938","type":"PrintfTickFormatter"},{"attributes":{"bottom":{"expr":{"id":"7961"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#2171b5"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#2171b5"},"line_alpha":{"value":0.2},"line_color":{"value":"#2171b5"},"top":{"expr":{"id":"7962"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7969","type":"VBar"},{"attributes":{"coordinates":null,"formatter":{"id":"7938"},"group":null,"major_label_policy":{"id":"7975"},"ticker":{"id":"7956"}},"id":"7955","type":"LinearAxis"},{"attributes":{"label":{"value":"External"},"renderers":[{"id":"7970"}]},"id":"7994","type":"LegendItem"},{"attributes":{"below":[{"id":"7951"}],"center":[{"id":"7954"},{"id":"7958"},{"id":"7993"}],"height":200,"left":[{"id":"7955"}],"renderers":[{"id":"7970"},{"id":"8000"}],"sizing_mode":"scale_width","title":{"id":"7941"},"toolbar":{"id":"7959"},"width":800,"x_range":{"id":"7943"},"x_scale":{"id":"7947"},"y_range":{"id":"7945"},"y_scale":{"id":"7949"}},"id":"7940","subtype":"Figure","type":"Plot"},{"attributes":{"fields":["External"]},"id":"7962","type":"Stack"},{"attributes":{"end":1645142400000.0,"start":1542153600000.0},"id":"7943","type":"Range1d"},{"attributes":{},"id":"7978","type":"AllLabels"},{"attributes":{},"id":"7975","type":"AllLabels"},{"attributes":{"bottom":{"expr":{"id":"7963"}},"fill_alpha":{"value":0.2},"fill_color":{"value":"#6baed6"},"hatch_alpha":{"value":0.2},"hatch_color":{"value":"#6baed6"},"line_alpha":{"value":0.2},"line_color":{"value":"#6baed6"},"top":{"expr":{"id":"7964"}},"width":{"value":2160000000.0},"x":{"field":"month"}},"id":"7999","type":"VBar"},{"attributes":{"tools":[{"id":"7939"}]},"id":"7959","type":"Toolbar"},{"attributes":{},"id":"7956","type":"BasicTicker"},{"attributes":{"coordinates":null,"data_source":{"id":"7995"},"glyph":{"id":"7997"},"group":null,"hover_glyph":null,"muted_glyph":{"id":"7999"},"name":"Internal","nonselection_glyph":{"id":"7998"},"view":{"id":"8001"}},"id":"8000","type":"GlyphRenderer"},{"attributes":{"days":[1,8,15,22]},"id":"7986","type":"DaysTicker"},{"attributes":{"source":{"id":"7965"}},"id":"7971","type":"CDSView"}],"root_ids":["7940"]},"title":"Bokeh Application","version":"2.4.2"}}
         </script>
@@ -49,11 +49,11 @@
               Bokeh.safely(function() {
                 (function(root) {
                   function embed_document(root) {
-                    
+
                   const docs_json = document.getElementById('8301').textContent;
                   const render_items = [{"docid":"9fe17bbf-95ed-4d31-8ef9-1932ff846d38","root_ids":["7940"],"roots":{"7940":"0fdf4875-b65b-43b9-87e9-7f2c33fc9eef"}}];
                   root.Bokeh.embed.embed_items(docs_json, render_items);
-                
+
                   }
                   if (root.Bokeh !== undefined) {
                     embed_document(root);
@@ -79,7 +79,7 @@
             else document.addEventListener("DOMContentLoaded", fn);
           })();
         </script>
-    
+
   </body>
-  
+
 </html>

--- a/status/packages.md
+++ b/status/packages.md
@@ -235,4 +235,3 @@ file: ../images/metrics/xpersist-contributors.html
 file: ../images/metrics/xpersist-burndown.html
 ---
 :::
-


### PR DESCRIPTION
The new `nightly` CI build of the Xdev site downloads updated data on PIP/conda downloads, GitHub commits/issues, and other relevant data on our packages.  It then autogenerates new pages and images for the site based on that updated data.  Unfortunately, the autogenerated images and pages do not conform to linting standards, so there are 2 approaches:

1. skip pre-commit on all autogenerated content, or
2. fix all autogenerated content *with pre-commit*.

I've opted for the second option.  So, now the `nightly` build does the following:

1. clone the GitHub repo,
2. setup miniconda environment,
3. setup Google authentication for access to Google BigQuery (needed to get PIP download statistics),
4. update download statistics (i.e., run `cli/getdownloads.py`),
5. update GitHub statistics (i.e., run `cli/getghstats.py`) using a GraphQL query or two,
6. autogenerate a new `status/packages.md` page and images on that page (i.e., run `cli/mkpkgs.py`),
7. autogenerate a new `status/tutorials.md` page (i.e., run `cli/mktuts.py`),
8. **NEW** install `pre-commit` and run `pre-commit run --all` to fix autogenerated content,
9. commit new changes to the repo,
10. build the JupyterBook site,
11. deploy to GitHub pages.

There is redundancy with the `nightly` workflow and the `build-deploy` workflow, but I think that's okay for now.